### PR TITLE
Handle Windows' CRLF newlines by transforming them to LFs before parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function parse(content) {
 	var parser = function(content) { // Perform parser in async so the function will return the emitter otherwise an error could be thrown before the emitter is ready
 		var ref = {};
 		var refField; // Currently appending ref field
-		if(content.indexOf("\r\n") !== -1) content = content.replace(/\r\n/g, "\n"); // Quickly detect, then normalise any Windows CRLF newlines to LFs.
+		content = content.replace(/\r\n/g, "\n"); // Normalise any Windows CRLF newlines to LFs.
 		(content + "\n").split("\n").forEach(function(line) {
 			var bits = /^(....)- (.*)$/.exec(line);
 			if (bits) {

--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ function parse(content) {
 	var parser = function(content) { // Perform parser in async so the function will return the emitter otherwise an error could be thrown before the emitter is ready
 		var ref = {};
 		var refField; // Currently appending ref field
+		if(content.indexOf("\r\n") !== -1) content = content.replace(/\r\n/g, "\n"); // Quickly detect, then normalise any Windows CRLF newlines to LFs.
 		(content + "\n").split("\n").forEach(function(line) {
 			var bits = /^(....)- (.*)$/.exec(line);
 			if (bits) {

--- a/test/data/language-CRLF.nbib
+++ b/test/data/language-CRLF.nbib
@@ -1,0 +1,3219 @@
+PMID- 20691275
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20110119
+LR  - 20101022
+IS  - 1095-9572 (Electronic)
+IS  - 1053-8119 (Linking)
+VI  - 54
+IP  - 1
+DP  - 2011 Jan 1
+TI  - Domain-general mechanisms of complex working memory span.
+PG  - 550-9
+LID - 10.1016/j.neuroimage.2010.07.067 [doi]
+AB  - A new fMRI complex working memory span paradigm was used to identify brain regions 
+      making domain-general contributions to working memory task performance. For both 
+      verbal and spatial versions of the task, complex working memory span performance 
+      increased the activity in lateral prefrontal, anterior cingulate, and parietal 
+      cortices during the Encoding, Maintenance, and Coordination phase of task 
+      performance. Meanwhile, overlapping activity in anterior prefrontal and medial 
+      temporal lobe regions was associated with both verbal and spatial recall from 
+      working memory. These findings help to adjudicate several contested issues regarding 
+      the executive mechanisms of working memory, the separability of short-term and 
+      working memory in the verbal and spatial domains, and the relative contribution of 
+      short-term and long-term memory mechanisms to working memory capacity. The study 
+      also provides a vital bridge between psychometric and neuroimaging approaches to 
+      working memory, and constrains our understanding of how working memory may 
+      contribute to the broader landscape of cognitive performance.
+CI  - Copyright © 2010 Elsevier Inc. All rights reserved.
+FAU - Chein, Jason M
+AU  - Chein JM
+AD  - Temple University, Department of Psychology, Philadelphia PA 19122, USA. 
+      jchein@temple.edu
+FAU - Moore, Adam B
+AU  - Moore AB
+FAU - Conway, Andrew R A
+AU  - Conway AR
+LA  - eng
+PT  - Journal Article
+DEP - 20100804
+PL  - United States
+TA  - Neuroimage
+JT  - NeuroImage
+JID - 9215515
+SB  - IM
+MH  - Brain/*physiology
+MH  - Brain Mapping/methods
+MH  - Cerebellum/physiology
+MH  - Cognition
+MH  - Frontal Lobe/physiology
+MH  - Functional Laterality
+MH  - Humans
+MH  - Magnetic Resonance Imaging/*methods
+MH  - Memory, Short-Term/*physiology
+MH  - Mesencephalon/physiology
+MH  - Neurons/physiology
+MH  - Speech
+MH  - Task Performance and Analysis
+MH  - Thalamus/physiology
+MH  - Young Adult
+EDAT- 2010/08/10 06:00
+MHDA- 2011/01/20 06:00
+CRDT- 2010/08/10 06:00
+PHST- 2009/09/09 00:00 [received]
+PHST- 2010/06/03 00:00 [revised]
+PHST- 2010/07/22 00:00 [accepted]
+PHST- 2010/08/10 06:00 [entrez]
+PHST- 2010/08/10 06:00 [pubmed]
+PHST- 2011/01/20 06:00 [medline]
+AID - S1053-8119(10)01059-1 [pii]
+AID - 10.1016/j.neuroimage.2010.07.067 [doi]
+PST - ppublish
+SO  - Neuroimage. 2011 Jan 1;54(1):550-9. doi: 10.1016/j.neuroimage.2010.07.067. Epub 2010 
+      Aug 4.
+
+PMID- 28821674
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20171010
+LR  - 20190629
+IS  - 1529-2401 (Electronic)
+IS  - 0270-6474 (Print)
+IS  - 0270-6474 (Linking)
+VI  - 37
+IP  - 39
+DP  - 2017 Sep 27
+TI  - How Auditory Experience Differentially Influences the Function of Left and Right 
+      Superior Temporal Cortices.
+PG  - 9564-9573
+LID - 10.1523/JNEUROSCI.0846-17.2017 [doi]
+AB  - To investigate how hearing status, sign language experience, and task demands 
+      influence functional responses in the human superior temporal cortices (STC) we 
+      collected fMRI data from deaf and hearing participants (male and female), who either 
+      acquired sign language early or late in life. Our stimuli in all tasks were pictures 
+      of objects. We varied the linguistic and visuospatial processing demands in three 
+      different tasks that involved decisions about (1) the sublexical (phonological) 
+      structure of the British Sign Language (BSL) signs for the objects, (2) the semantic 
+      category of the objects, and (3) the physical features of the objects.Neuroimaging 
+      data revealed that in participants who were deaf from birth, STC showed increased 
+      activation during visual processing tasks. Importantly, this differed across 
+      hemispheres. Right STC was consistently activated regardless of the task whereas 
+      left STC was sensitive to task demands. Significant activation was detected in the 
+      left STC only for the BSL phonological task. This task, we argue, placed greater 
+      demands on visuospatial processing than the other two tasks. In hearing signers, 
+      enhanced activation was absent in both left and right STC during all three tasks. 
+      Lateralization analyses demonstrated that the effect of deafness was more 
+      task-dependent in the left than the right STC whereas it was more task-independent 
+      in the right than the left STC. These findings indicate how the absence of auditory 
+      input from birth leads to dissociable and altered functions of left and right STC in 
+      deaf participants.SIGNIFICANCE STATEMENT Those born deaf can offer unique insights 
+      into neuroplasticity, in particular in regions of superior temporal cortex (STC) 
+      that primarily respond to auditory input in hearing people. Here we demonstrate that 
+      in those deaf from birth the left and the right STC have altered and dissociable 
+      functions. The right STC was activated regardless of demands on visual processing. 
+      In contrast, the left STC was sensitive to the demands of visuospatial processing. 
+      Furthermore, hearing signers, with the same sign language experience as the deaf 
+      participants, did not activate the STCs. Our data advance current understanding of 
+      neural plasticity by determining the differential effects that hearing status and 
+      task demands can have on left and right STC function.
+CI  - Copyright © 2017 Twomey et al.
+FAU - Twomey, Tae
+AU  - Twomey T
+AUID- ORCID: 0000-0001-9749-5895
+AD  - ESRC Deafness, Cognition and Language Research Centre, University College London, 
+      WC1H 0PD, United Kingdom.
+AD  - Institute of Cognitive Neuroscience, University College London, WC1N 3AR, United 
+      Kingdom.
+FAU - Waters, Dafydd
+AU  - Waters D
+AD  - ESRC Deafness, Cognition and Language Research Centre, University College London, 
+      WC1H 0PD, United Kingdom.
+FAU - Price, Cathy J
+AU  - Price CJ
+AUID- ORCID: 0000-0001-7448-4835
+AD  - Wellcome Trust Centre for Neuroimaging, Institute of Neurology, University College 
+      London, WC1N 3BG, United Kingdom, and.
+FAU - Evans, Samuel
+AU  - Evans S
+AUID- ORCID: 0000-0001-9667-0671
+AD  - Institute of Cognitive Neuroscience, University College London, WC1N 3AR, United 
+      Kingdom.
+AD  - Psychology Department, University of Westminster, 115 New Cavendish Street, London, 
+      W1W 6UW.
+FAU - MacSweeney, Mairéad
+AU  - MacSweeney M
+AUID- ORCID: 0000-0002-2315-3507
+AD  - ESRC Deafness, Cognition and Language Research Centre, University College London, 
+      WC1H 0PD, United Kingdom, m.macsweeney@ucl.ac.uk.
+AD  - Institute of Cognitive Neuroscience, University College London, WC1N 3AR, United 
+      Kingdom.
+LA  - eng
+GR  - Wellcome Trust/United Kingdom
+GR  - MR/M023672/1/Medical Research Council/United Kingdom
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20170818
+TA  - J Neurosci
+JT  - The Journal of neuroscience : the official journal of the Society for Neuroscience
+JID - 8102140
+SB  - IM
+MH  - Adult
+MH  - *Auditory Perception
+MH  - Brain Mapping
+MH  - Case-Control Studies
+MH  - Deafness/*physiopathology
+MH  - Female
+MH  - *Functional Laterality
+MH  - Humans
+MH  - Magnetic Resonance Imaging
+MH  - Male
+MH  - *Memory, Short-Term
+MH  - Middle Aged
+MH  - Semantics
+MH  - *Sign Language
+MH  - Temporal Lobe/*physiology/physiopathology
+MH  - Visual Perception
+PMC - PMC5618270
+OTO - NOTNLM
+OT  - *deaf
+OT  - *language
+OT  - *plasticity
+OT  - *sign language
+OT  - *superior temporal cortex
+OT  - *visuo-spatial working memory
+EDAT- 2017/08/20 06:00
+MHDA- 2017/10/11 06:00
+CRDT- 2017/08/20 06:00
+PHST- 2017/03/28 00:00 [received]
+PHST- 2017/07/25 00:00 [revised]
+PHST- 2017/07/27 00:00 [accepted]
+PHST- 2017/08/20 06:00 [pubmed]
+PHST- 2017/10/11 06:00 [medline]
+PHST- 2017/08/20 06:00 [entrez]
+AID - JNEUROSCI.0846-17.2017 [pii]
+AID - 0846-17 [pii]
+AID - 10.1523/JNEUROSCI.0846-17.2017 [doi]
+PST - ppublish
+SO  - J Neurosci. 2017 Sep 27;37(39):9564-9573. doi: 10.1523/JNEUROSCI.0846-17.2017. Epub 
+      2017 Aug 18.
+
+PMID- 21056593
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20110418
+LR  - 20101227
+IS  - 1872-7549 (Electronic)
+IS  - 0166-4328 (Linking)
+VI  - 217
+IP  - 2
+DP  - 2011 Mar 1
+TI  - Functional cerebral lateralization and dual-task efficiency-testing the function of 
+      human brain lateralization using fTCD.
+PG  - 293-301
+LID - 10.1016/j.bbr.2010.10.029 [doi]
+AB  - It has been hypothesized that functional cerebral lateralization enhances cognitive 
+      performance. Evidence was found in birds and fish. Our study aimed to test this 
+      hypothesis by analyzing the relationship between cerebral lateralization and both 
+      single-task performance and dual-task efficiency in humans. We combined a dynamic 
+      Landmark task which is assumed to be primarily processed in the right hemisphere and 
+      a frequently used word generation task which is assumed to be primarily processed in 
+      the left hemisphere. For each task individual strength and direction of hemispheric 
+      lateralization was assessed using functional transcranial Doppler sonography (fTCD). 
+      For each subject (15 women, 11 men), performance was measured in the two 
+      single-tasks and in the dual-task condition. Performance was not related to strength 
+      or direction of lateralization in single-tasks. With regard to dual-task efficiency, 
+      we found the expected advantage of having a typical lateralization pattern. 
+      Moreover, the results showed a slight negative, rather than a positive, relationship 
+      between strength of lateralization and dual-task efficiency. Further analysis showed 
+      that this negative relationship may only be present in subjects showing 
+      non-significant lateralization for one or both tasks. Therefore, the hypothesis that 
+      cerebral lateralization enhances human cognitive performance is too general: having 
+      two functions significantly lateralized to different hemispheres enhances dual-task 
+      efficiency, in this group strength of lateralized does not matter. However, if one 
+      or both functions are not significantly lateralized overall performance is worse and 
+      in this group, performance is negatively related to increased strength of 
+      lateralization.
+CI  - Copyright Â© 2010 Elsevier B.V. All rights reserved.
+FAU - Lust, J M
+AU  - Lust JM
+AD  - Department of Clinical and Developmental NeuroPsychology, University of Groningen, 
+      Grote Kruisstraat 2/1, 9712 TS Groningen, The Netherlands.
+FAU - Geuze, R H
+AU  - Geuze RH
+FAU - Groothuis, A G G
+AU  - Groothuis AG
+FAU - Bouma, A
+AU  - Bouma A
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20101105
+PL  - Netherlands
+TA  - Behav Brain Res
+JT  - Behavioural brain research
+JID - 8004872
+SB  - IM
+MH  - Brain/*blood supply/*physiology
+MH  - *Brain Mapping
+MH  - Cerebrovascular Circulation/*physiology
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Language
+MH  - Male
+MH  - Neuropsychological Tests
+MH  - Spatial Behavior/physiology
+MH  - Statistics as Topic
+MH  - Ultrasonography, Doppler
+MH  - *Ultrasonography, Doppler, Transcranial
+MH  - Vocabulary
+MH  - Young Adult
+EDAT- 2010/11/09 06:00
+MHDA- 2011/04/19 06:00
+CRDT- 2010/11/09 06:00
+PHST- 2010/06/15 00:00 [received]
+PHST- 2010/10/18 00:00 [revised]
+PHST- 2010/10/22 00:00 [accepted]
+PHST- 2010/11/09 06:00 [entrez]
+PHST- 2010/11/09 06:00 [pubmed]
+PHST- 2011/04/19 06:00 [medline]
+AID - S0166-4328(10)00714-X [pii]
+AID - 10.1016/j.bbr.2010.10.029 [doi]
+PST - ppublish
+SO  - Behav Brain Res. 2011 Mar 1;217(2):293-301. doi: 10.1016/j.bbr.2010.10.029. Epub 
+      2010 Nov 5.
+
+PMID- 19439393
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20091019
+LR  - 20191210
+IS  - 1618-3169 (Print)
+IS  - 1618-3169 (Linking)
+VI  - 56
+IP  - 4
+DP  - 2009
+TI  - The Simon effect with conventional signals: a time-course analysis.
+PG  - 219-27
+LID - 10.1027/1618-3169.56.4.219 [doi]
+AB  - The Simon effect consists of a faster and a more accurate performance when spatial 
+      responses correspond to irrelevant-spatial stimuli than when they do not. The time 
+      course of the Simon effect was investigated using centrally presented conventional 
+      signals (arrows and spatial words) conveying spatial information through 
+      iconic-symbolic (Experiments 1 and 2) and semantic (Experiment 3) codes. 
+      Time-demanding object-inherent and semantic spatial codes were generated for arrows 
+      and words, respectively. This resulted in Simon effects increasing in size across 
+      increasing response times (RTs). However, different onsets of the Simon effect were 
+      displayed across RT distributions. For arrows, the Simon effect was already 
+      significant at the fastest RT intervals, providing clear evidence that they are 
+      distinctively more effective directional indicators compared to words.
+FAU - Pellicano, Antonello
+AU  - Pellicano A
+AD  - University of Bologna, Bologna, Italy. antonio.pellicano@unibo.it
+FAU - Lugli, Luisa
+AU  - Lugli L
+FAU - Baroni, Giulia
+AU  - Baroni G
+FAU - Nicoletti, Roberto
+AU  - Nicoletti R
+LA  - eng
+PT  - Journal Article
+PL  - Germany
+TA  - Exp Psychol
+JT  - Experimental psychology
+JID - 101138477
+SB  - IM
+MH  - *Attention
+MH  - *Conflict, Psychological
+MH  - *Functional Laterality
+MH  - Humans
+MH  - *Orientation
+MH  - *Pattern Recognition, Visual
+MH  - *Psychomotor Performance
+MH  - *Reaction Time
+MH  - Semantics
+EDAT- 2009/05/15 09:00
+MHDA- 2009/10/20 06:00
+CRDT- 2009/05/15 09:00
+PHST- 2009/05/15 09:00 [entrez]
+PHST- 2009/05/15 09:00 [pubmed]
+PHST- 2009/10/20 06:00 [medline]
+AID - 547T748243783H83 [pii]
+AID - 10.1027/1618-3169.56.4.219 [doi]
+PST - ppublish
+SO  - Exp Psychol. 2009;56(4):219-27. doi: 10.1027/1618-3169.56.4.219.
+
+PMID- 12684205
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20030828
+LR  - 20191025
+IS  - 0010-0277 (Print)
+IS  - 0010-0277 (Linking)
+VI  - 87
+IP  - 3
+DP  - 2003 Apr
+TI  - The mental representation of ordinal sequences is spatially organized.
+PG  - B87-95
+AB  - In the domain of numbers the existence of spatial components in the representation 
+      of numerical magnitude has been convincingly demonstrated by an association between 
+      number magnitude and response preference with faster left- than right-hand responses 
+      for small numbers and faster right- than left-hand responses for large numbers 
+      (Dehaene, S., Bossini, S., & Giraux, P. (1993) The mental representation of parity 
+      and number magnitude. Journal of Experimental Psychology: General, 122, 371-396). 
+      Because numbers convey not only real or integer meaning but also ordinal meaning, 
+      the question of whether non-numerical ordinal information is spatially coded 
+      naturally follows. While previous research failed to show an association between 
+      ordinal position and spatial response preference, we present two experiments 
+      involving months (Experiment 1) and letters (Experiment 2) in which spatial coding 
+      is demonstrated. Furthermore, the response-side effect was obtained with two 
+      different stimulus-response mappings. The association occurred both when ordinal 
+      information was relevant and when it was irrelevant to the task, showing that the 
+      spatial component of the ordinal representation can be automatically activated.
+FAU - Gevers, Wim
+AU  - Gevers W
+AD  - Department of Experimental Psychology, Ghent University, H. Dunantlaan 2, B-9000 
+      Ghent, Belgium. wim.gevers@rug.ac.be
+FAU - Reynvoet, Bert
+AU  - Reynvoet B
+FAU - Fias, Wim
+AU  - Fias W
+LA  - eng
+PT  - Comparative Study
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+PL  - Netherlands
+TA  - Cognition
+JT  - Cognition
+JID - 0367541
+SB  - IM
+MH  - Adult
+MH  - *Cognition
+MH  - *Concept Formation
+MH  - Functional Laterality
+MH  - Humans
+MH  - Language
+MH  - Mathematics
+MH  - *Problem Solving
+MH  - Reaction Time
+MH  - Task Performance and Analysis
+EDAT- 2003/04/10 05:00
+MHDA- 2003/08/29 05:00
+CRDT- 2003/04/10 05:00
+PHST- 2003/04/10 05:00 [pubmed]
+PHST- 2003/08/29 05:00 [medline]
+PHST- 2003/04/10 05:00 [entrez]
+AID - S0010027702002342 [pii]
+AID - 10.1016/s0010-0277(02)00234-2 [doi]
+PST - ppublish
+SO  - Cognition. 2003 Apr;87(3):B87-95. doi: 10.1016/s0010-0277(02)00234-2.
+
+PMID- 11194413
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20010215
+LR  - 20191025
+IS  - 0001-6918 (Print)
+IS  - 0001-6918 (Linking)
+VI  - 105
+IP  - 2-3
+DP  - 2000 Dec
+TI  - Lateralization of cognitive processes in the brain.
+PG  - 211-35
+AB  - The lateralization of cognitive processes in the brain is discussed. The traditional 
+      view of a language-visuo/spatial dichotomy of function between the hemispheres has 
+      been replaced by more subtle distinctions. The use of magnetic resonance imaging 
+      (MRI) to study brain morphology has resulted in a renewed focus on the relationship 
+      between structural and functional asymmetry. Focus has been on the role played by 
+      the planum temporale area in the posterior part of the superior temporal gyrus for 
+      language asymmetry, and the possible significance of the larger left planum. The 
+      dichotic listening technique is used to illustrate the difference between bottom-up, 
+      or stimulus-driven laterality versus top-down, or instruction-driven laterality. It 
+      is suggested that the hemispheric dominance observed at any time is the sum result 
+      of the dynamic interaction between bottom-up and top-down processing tendencies. 
+      Stimulus-driven laterality dominance is always monitored and modulated through 
+      top-down cognitive processes, like shifting of attention and changes in arousal. A 
+      model of top-down modulation of bottom-up laterality is presented with special 
+      reference to the understanding of psychiatric disorders.
+FAU - Hugdahl, K
+AU  - Hugdahl K
+AD  - Department of Biological and Medical Psychology, University of Bergen, Arstadveien 
+      21, 5009 Bergen, Norway. hugdahl@psych.uib.no
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+PT  - Review
+PL  - Netherlands
+TA  - Acta Psychol (Amst)
+JT  - Acta psychologica
+JID - 0370366
+SB  - IM
+MH  - Adult
+MH  - Aged
+MH  - Arachnoid Cysts/physiopathology
+MH  - Auditory Pathways
+MH  - Cognition/*physiology
+MH  - Female
+MH  - *Functional Laterality
+MH  - Humans
+MH  - Male
+MH  - Middle Aged
+MH  - *Neurolinguistic Programming
+MH  - Schizophrenia/physiopathology
+MH  - Temporal Lobe/physiology/physiopathology
+RF  - 92
+EDAT- 2001/02/24 12:00
+MHDA- 2001/03/03 10:01
+CRDT- 2001/02/24 12:00
+PHST- 2001/02/24 12:00 [pubmed]
+PHST- 2001/03/03 10:01 [medline]
+PHST- 2001/02/24 12:00 [entrez]
+AID - 10.1016/s0001-6918(00)00062-7 [doi]
+PST - ppublish
+SO  - Acta Psychol (Amst). 2000 Dec;105(2-3):211-35. doi: 10.1016/s0001-6918(00)00062-7.
+
+PMID- 27450303
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20170901
+LR  - 20181202
+IS  - 1525-5069 (Electronic)
+IS  - 1525-5050 (Linking)
+VI  - 62
+DP  - 2016 Sep
+TI  - An improved qEEG index for asymmetry detection during the Wada test.
+PG  - 40-6
+LID - S1525-5050(16)30164-0 [pii]
+LID - 10.1016/j.yebeh.2016.06.009 [doi]
+AB  - The Wada test is commonly used to evaluate language and memory lateralization in 
+      candidates for epilepsy surgery. The spatial Brain Symmetry Index (BSI) quantifies 
+      inter-hemispheric differences in the EEG. Its application has been shown to be 
+      feasible during Wada testing. We developed a method for the quantification of EEG 
+      asymmetry that matches visual assessments of the EEG better than BSI. Fifty-three 
+      patients' EEG data, with a total of 85 injections were analyzed. In a step-wise, 
+      data-driven manner, multiple electrode and frequency band combinations were 
+      evaluated. Eventually, BSI, calculated using only the frontal electrodes F3 and F4, 
+      was combined with a temporal measure of delta power in the central electrodes, C3 
+      and C4, into a new measure: cBSI. Using the area under the ROC curve (AUC), we 
+      showed that cBSI performs significantly better relative to BSI (median AUC 0.98 
+      versus 0.96, p=0.0015, Wilcoxon signed rank test). Our results showed that asymmetry 
+      detection was significantly improved by combining temporal with spatial qEEG 
+      measures. In the future, our combined qEEG measure could allow for a more objective 
+      way of monitoring EEG asymmetry, thereby increasing the feasibility of using EEG as 
+      a monitoring tool during the Wada test. Future studies should, however, validate our 
+      cBSI method in real time in the operating room or radiology suite.
+CI  - Copyright © 2016 Elsevier Inc. All rights reserved.
+FAU - Bogaarts, Guy
+AU  - Bogaarts G
+AD  - Department of Clinical Neurophysiology, AZM Maastricht, Netherlands. Electronic 
+      address: guybogaarts@gmail.com.
+FAU - Gommer, Erik
+AU  - Gommer E
+AD  - Department of Clinical Neurophysiology, AZM Maastricht, Netherlands.
+FAU - Hilkman, Danny
+AU  - Hilkman D
+AD  - Department of Clinical Neurophysiology, AZM Maastricht, Netherlands.
+FAU - van Kranen-Mastenbroek, Vivianne
+AU  - van Kranen-Mastenbroek V
+AD  - Department of Clinical Neurophysiology, AZM Maastricht, Netherlands.
+FAU - Reulen, Jos
+AU  - Reulen J
+AD  - Department of Clinical Neurophysiology, AZM Maastricht, Netherlands.
+LA  - eng
+PT  - Journal Article
+DEP - 20160720
+PL  - United States
+TA  - Epilepsy Behav
+JT  - Epilepsy & behavior : E&B
+JID - 100892858
+SB  - IM
+MH  - Adult
+MH  - Brain/*physiopathology
+MH  - Electrodes
+MH  - Electroencephalography/*methods
+MH  - Epilepsy/*physiopathology/surgery
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - *Language
+MH  - Male
+MH  - Memory/*physiology
+MH  - Middle Aged
+MH  - Monitoring, Physiologic
+MH  - Young Adult
+OTO - NOTNLM
+OT  - *Brain symmetry index
+OT  - *Epilepsy surgery
+OT  - *Intracarotid amobarbital procedure
+OT  - *Neuromonitoring
+OT  - *Quantitative electroencephalography
+OT  - *Wada test
+EDAT- 2016/07/28 06:00
+MHDA- 2017/09/02 06:00
+CRDT- 2016/07/25 06:00
+PHST- 2016/02/12 00:00 [received]
+PHST- 2016/06/10 00:00 [revised]
+PHST- 2016/06/13 00:00 [accepted]
+PHST- 2016/07/25 06:00 [entrez]
+PHST- 2016/07/28 06:00 [pubmed]
+PHST- 2017/09/02 06:00 [medline]
+AID - S1525-5050(16)30164-0 [pii]
+AID - 10.1016/j.yebeh.2016.06.009 [doi]
+PST - ppublish
+SO  - Epilepsy Behav. 2016 Sep;62:40-6. doi: 10.1016/j.yebeh.2016.06.009. Epub 2016 Jul 
+      20.
+
+PMID- 20136220
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20100624
+LR  - 20181113
+IS  - 1520-8524 (Electronic)
+IS  - 0001-4966 (Print)
+IS  - 0001-4966 (Linking)
+VI  - 127
+IP  - 2
+DP  - 2010 Feb
+TI  - Effects of simulated spectral holes on speech intelligibility and spatial release 
+      from masking under binaural and monaural listening.
+PG  - 977-89
+LID - 10.1121/1.3273897 [doi]
+AB  - The possibility that "dead regions" or "spectral holes" can account for some 
+      differences in performance between bilateral cochlear implant (CI) users and 
+      normal-hearing listeners was explored. Using a 20-band noise-excited vocoder to 
+      simulate CI processing, this study examined effects of spectral holes on speech 
+      reception thresholds (SRTs) and spatial release from masking (SRM) in difficult 
+      listening conditions. Prior to processing, stimuli were convolved through 
+      head-related transfer-functions to provide listeners with free-field directional 
+      cues. Processed stimuli were presented over headphones under binaural or monaural 
+      (right ear) conditions. Using Greenwood's [(1990). J. Acoust. Soc. Am. 87, 
+      2592-2605] frequency-position function and assuming a cochlear length of 35 mm, 
+      spectral holes were created for variable sizes (6 and 10 mm) and locations (base, 
+      middle, and apex). Results show that middle-frequency spectral holes were the most 
+      disruptive to SRTs, whereas high-frequency spectral holes were the most disruptive 
+      to SRM. Spectral holes generally reduced binaural advantages in difficult listening 
+      conditions. These results suggest the importance of measuring dead regions in CI 
+      users. It is possible that customized programming for bilateral CI processors based 
+      on knowledge about dead regions can enhance performance in adverse listening 
+      situations.
+FAU - Garadat, Soha N
+AU  - Garadat SN
+AD  - Waisman Center, University of Wisconsin, 1500 Highland Avenue, Madison, Wisconsin 
+      53705, USA.
+FAU - Litovsky, Ruth Y
+AU  - Litovsky RY
+FAU - Yu, Gongqiang
+AU  - Yu G
+FAU - Zeng, Fan-Gang
+AU  - Zeng FG
+LA  - eng
+GR  - R01 DC003083/DC/NIDCD NIH HHS/United States
+GR  - R29 DC003083/DC/NIDCD NIH HHS/United States
+GR  - R01DC030083/DC/NIDCD NIH HHS/United States
+PT  - Journal Article
+PT  - Research Support, N.I.H., Extramural
+TA  - J Acoust Soc Am
+JT  - The Journal of the Acoustical Society of America
+JID - 7503051
+SB  - IM
+CIN - (1990). J. Acoust. Soc. Am. 87, 2592–2605. PMID: 2373794
+MH  - Acoustic Stimulation
+MH  - Adult
+MH  - Auditory Threshold
+MH  - Cochlea/anatomy & histology
+MH  - *Cochlear Implants
+MH  - Cues
+MH  - *Ear
+MH  - Female
+MH  - *Functional Laterality
+MH  - Head
+MH  - Humans
+MH  - Male
+MH  - Psychoacoustics
+MH  - Space Perception
+MH  - *Speech
+MH  - *Speech Perception
+MH  - Young Adult
+PMC - PMC2830263
+EDAT- 2010/02/09 06:00
+MHDA- 2010/06/25 06:00
+CRDT- 2010/02/09 06:00
+PHST- 2010/02/09 06:00 [entrez]
+PHST- 2010/02/09 06:00 [pubmed]
+PHST- 2010/06/25 06:00 [medline]
+AID - 012002JAS [pii]
+AID - 10.1121/1.3273897 [doi]
+PST - ppublish
+SO  - J Acoust Soc Am. 2010 Feb;127(2):977-89. doi: 10.1121/1.3273897.
+
+PMID- 16054741
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20060110
+LR  - 20061115
+IS  - 0278-2626 (Print)
+IS  - 0278-2626 (Linking)
+VI  - 59
+IP  - 2
+DP  - 2005 Nov
+TI  - Are there pre-existing neural, cognitive, or motoric markers for musical ability?
+PG  - 124-34
+AB  - Adult musician's brains show structural enlargements, but it is not known whether 
+      these are inborn or a consequence of long-term training. In addition, music training 
+      in childhood has been shown to have positive effects on visual-spatial and verbal 
+      outcomes. However, it is not known whether pre-existing advantages in these skills 
+      are found in children who choose to study a musical instrument nor is it known 
+      whether there are pre-existing associations between music and any of these outcome 
+      measures that could help explain the training effects. To answer these questions, we 
+      compared 5- to 7-year-olds beginning piano or string lessons (n=39) with 5- to 
+      7-year-olds not beginning instrumental training (n=31). All children received a 
+      series of tests (visual-spatial, non-verbal reasoning, verbal, motor, and musical) 
+      and underwent magnetic resonance imaging. We found no pre-existing neural, 
+      cognitive, motor, or musical differences between groups and no correlations (after 
+      correction for multiple analyses) between music perceptual skills and any brain or 
+      visual-spatial measures. However, correlations were found between music perceptual 
+      skills and both non-verbal reasoning and phonemic awareness. Such pre-existing 
+      correlations suggest similarities in auditory and visual pattern recognition as well 
+      a sharing of the neural substrates for language and music processing, most likely 
+      due to innate abilities or implicit learning during early development. This baseline 
+      study lays the groundwork for an ongoing longitudinal study addressing the effects 
+      of intensive musical training on brain and cognitive development, and making it 
+      possible to look retroactively at the brain and cognitive development of those 
+      children who emerge showing exceptional musical talent.
+FAU - Norton, Andrea
+AU  - Norton A
+AD  - Department of Neurology, Beth Israel Deaconess Medical Center, Harvard Medical 
+      School, USA.
+FAU - Winner, Ellen
+AU  - Winner E
+FAU - Cronin, Karl
+AU  - Cronin K
+FAU - Overy, Katie
+AU  - Overy K
+FAU - Lee, Dennis J
+AU  - Lee DJ
+FAU - Schlaug, Gottfried
+AU  - Schlaug G
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+PT  - Research Support, U.S. Gov't, Non-P.H.S.
+DEP - 20050728
+PL  - United States
+TA  - Brain Cogn
+JT  - Brain and cognition
+JID - 8218014
+SB  - IM
+MH  - Awareness/physiology
+MH  - Child
+MH  - Choice Behavior
+MH  - Cognition/*physiology
+MH  - Female
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - Magnetic Resonance Imaging
+MH  - Male
+MH  - Motor Cortex/*anatomy & histology/*physiology
+MH  - *Music
+MH  - Nerve Net/*physiology
+MH  - Neuropsychological Tests
+MH  - Phonetics
+MH  - *Psychomotor Performance
+MH  - Space Perception
+MH  - Visual Perception/physiology
+EDAT- 2005/08/02 09:00
+MHDA- 2006/01/13 09:00
+CRDT- 2005/08/02 09:00
+PHST- 2004/11/17 00:00 [received]
+PHST- 2005/03/24 00:00 [revised]
+PHST- 2005/05/29 00:00 [accepted]
+PHST- 2005/08/02 09:00 [pubmed]
+PHST- 2006/01/13 09:00 [medline]
+PHST- 2005/08/02 09:00 [entrez]
+AID - S0278-2626(05)00089-8 [pii]
+AID - 10.1016/j.bandc.2005.05.009 [doi]
+PST - ppublish
+SO  - Brain Cogn. 2005 Nov;59(2):124-34. doi: 10.1016/j.bandc.2005.05.009. Epub 2005 Jul 
+      28.
+
+PMID- 6839069
+OWN - NLM
+STAT- MEDLINE
+DCOM- 19830610
+LR  - 20190705
+IS  - 0007-1250 (Print)
+IS  - 0007-1250 (Linking)
+VI  - 142
+DP  - 1983 Feb
+TI  - The relationship of handedness to the cognitive, language, and visuo-spatial skills 
+      of autistic patients.
+PG  - 156-62
+AB  - The relationship between hand preference, age, and developmental functioning was 
+      examined in 70 autistic patients. Unilateral or mixed handedness appeared to be 
+      stabilized by the age of five years. Patients with established hand lateralization 
+      tended to function better in all developmental areas including intelligence, 
+      language, and visuospatial abilities. It is a tenable hypothesis that the presence 
+      or absence of hand lateralization by age five may be an important predictor of 
+      outcome in autism.
+FAU - Tsai, L Y
+AU  - Tsai LY
+LA  - eng
+PT  - Journal Article
+PL  - England
+TA  - Br J Psychiatry
+JT  - The British journal of psychiatry : the journal of mental science
+JID - 0342367
+SB  - IM
+MH  - Adolescent
+MH  - Age Factors
+MH  - Autistic Disorder/*psychology
+MH  - Child
+MH  - Child Development
+MH  - Child, Preschool
+MH  - Cognition
+MH  - Female
+MH  - *Functional Laterality
+MH  - Humans
+MH  - Intelligence
+MH  - Language Development
+MH  - Male
+EDAT- 1983/02/01 00:00
+MHDA- 1983/02/01 00:01
+CRDT- 1983/02/01 00:00
+PHST- 1983/02/01 00:00 [pubmed]
+PHST- 1983/02/01 00:01 [medline]
+PHST- 1983/02/01 00:00 [entrez]
+AID - S0007125000114382 [pii]
+AID - 10.1192/bjp.142.2.156 [doi]
+PST - ppublish
+SO  - Br J Psychiatry. 1983 Feb;142:156-62. doi: 10.1192/bjp.142.2.156.
+
+PMID- 26866655
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20171222
+LR  - 20191210
+IS  - 1939-1285 (Electronic)
+IS  - 0278-7393 (Linking)
+VI  - 42
+IP  - 8
+DP  - 2016 Aug
+TI  - A general valence asymmetry in similarity: Good is more alike than bad.
+PG  - 1171-92
+LID - 10.1037/xlm0000243 [doi]
+AB  - The density hypothesis (Unkelbach, Fiedler, Bayer, Stegmüller, & Danner, 2008) 
+      claims a general higher similarity of positive information to other positive 
+      information compared with the similarity of negative information to other negative 
+      information. This similarity asymmetry might explain valence asymmetries on all 
+      levels of cognitive processing. The available empirical evidence for this general 
+      valence asymmetry in similarity suffers from a lack of direct tests, low 
+      representativeness, and possible confounding variables (e.g., differential valence 
+      intensity, frequency, familiarity, or concreteness of positive and negative 
+      stimuli). To address these problems, Study 1 first validated the spatial arrangement 
+      method (SpAM) as a similarity measure. Using SpAM, Studies 2-6 found the proposed 
+      valence asymmetry in large, representative samples of self- and other-generated 
+      words (Studies 2a/2b), for words of consensual and idiosyncratic valence (Study 3), 
+      for words from 1 and many independent information sources (Study 4), for real-life 
+      experiences (Study 5), and for large data sets of verbal (i.e., ∼14,000 words 
+      reported by Warriner, Kuperman, & Brysbaert, 2013) and visual information (i.e., 
+      ∼1,000 pictures reported in the IAPS; Lang, Bradley, & Cuthbert, 2005; Study 6). 
+      Together, these data support a general valence asymmetry in similarity, namely that 
+      good is more alike than bad. (PsycINFO Database Record
+CI  - (c) 2016 APA, all rights reserved).
+FAU - Koch, Alex
+AU  - Koch A
+AD  - Social Cognition Center Cologne, University of Cologne.
+FAU - Alves, Hans
+AU  - Alves H
+AD  - Social Cognition Center Cologne, University of Cologne.
+FAU - Krüger, Tobias
+AU  - Krüger T
+AD  - University of Heidelberg.
+FAU - Unkelbach, Christian
+AU  - Unkelbach C
+AD  - Social Cognition Center Cologne, University of Cologne.
+LA  - eng
+PT  - Journal Article
+DEP - 20160211
+PL  - United States
+TA  - J Exp Psychol Learn Mem Cogn
+JT  - Journal of experimental psychology. Learning, memory, and cognition
+JID - 8207540
+SB  - IM
+MH  - Affect/*physiology
+MH  - Analysis of Variance
+MH  - Cognition
+MH  - Emotions/*physiology
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Male
+MH  - Photic Stimulation
+MH  - Reading
+MH  - Recognition, Psychology/*physiology
+MH  - Regression Analysis
+MH  - Semantics
+MH  - Students
+MH  - Universities
+MH  - Vocabulary
+EDAT- 2016/02/13 06:00
+MHDA- 2017/12/23 06:00
+CRDT- 2016/02/12 06:00
+PHST- 2016/02/12 06:00 [entrez]
+PHST- 2016/02/13 06:00 [pubmed]
+PHST- 2017/12/23 06:00 [medline]
+AID - 2016-07251-001 [pii]
+AID - 10.1037/xlm0000243 [doi]
+PST - ppublish
+SO  - J Exp Psychol Learn Mem Cogn. 2016 Aug;42(8):1171-92. doi: 10.1037/xlm0000243. Epub 
+      2016 Feb 11.
+
+PMID- 10929269
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20001207
+LR  - 20190831
+IS  - 0340-5354 (Print)
+IS  - 0340-5354 (Linking)
+VI  - 247
+IP  - 6
+DP  - 2000 Jun
+TI  - Semantic dementia: clinical, radiological and pathological perspectives.
+PG  - 409-22
+AB  - Semantic dementia (SD) is a recently described clinical syndrome characterised by an 
+      acquired progressive inability to name or comprehend common concepts, with little or 
+      no distortion of the phonological and syntactic aspects of language, and relative 
+      sparing of other aspects of cognition, such as episodic memory, nonverbal 
+      problem-solving, and perceptual and visuo-spatial skills. The cognitive locus of 
+      this syndrome appears to lie in the permanent store of long-term memory representing 
+      general world knowledge-semantic memory. The anatomical distribution of atrophy is 
+      less well-defined, and the contribution of various imaging modalities is discussed 
+      in the context of a body of 45 published and unpublished cases. We conclude that 
+      involvement of the left infero-lateral temporal cortex is the critical area in the 
+      genesis of SD. SD probably always represents a non-Alzheimer neurodegenerative 
+      process; a variety of pathological lesions may be present, and possible causes, 
+      together with debates about their correct classification, are discussed.
+FAU - Garrard, P
+AU  - Garrard P
+AD  - University of Cambridge Neurology Unit, Addenbrooke's Hospital, Cambridge, UK.
+FAU - Hodges, J R
+AU  - Hodges JR
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+PT  - Review
+PL  - Germany
+TA  - J Neurol
+JT  - Journal of neurology
+JID - 0423161
+SB  - IM
+MH  - Dementia/diagnostic imaging/*pathology/*physiopathology
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - Language Disorders/diagnostic imaging/pathology/*physiopathology
+MH  - Language Tests
+MH  - Memory Disorders/diagnostic imaging/*pathology/*physiopathology
+MH  - Radiography
+MH  - Temporal Lobe/*pathology/*physiopathology
+RF  - 95
+EDAT- 2000/08/10 11:00
+MHDA- 2001/02/28 10:01
+CRDT- 2000/08/10 11:00
+PHST- 2000/08/10 11:00 [pubmed]
+PHST- 2001/02/28 10:01 [medline]
+PHST- 2000/08/10 11:00 [entrez]
+AID - 10.1007/s004150070169 [doi]
+PST - ppublish
+SO  - J Neurol. 2000 Jun;247(6):409-22. doi: 10.1007/s004150070169.
+
+PMID- 18790081
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20090420
+LR  - 20090112
+IS  - 1525-5069 (Electronic)
+IS  - 1525-5050 (Linking)
+VI  - 14
+IP  - 1
+DP  - 2009 Jan
+TI  - Power spectral density changes and language lateralization during covert object 
+      naming tasks measured with high-density EEG recordings.
+PG  - 54-9
+LID - 10.1016/j.yebeh.2008.08.018 [doi]
+AB  - Our objective was to study changes in EEG time-domain power spectral density (PSDt) 
+      and localization of language areas during covert object naming tasks in human 
+      subjects with epilepsy. EEG data for subjects with epilepsy were acquired during the 
+      covert object naming tasks using a net of 256 electrodes. The trials required each 
+      subject to provide the names of common objects presented every 4 seconds on slides. 
+      Each trial comprised the 1.0 second before and 3.0 seconds after initial object 
+      presentation. PSDt values at baseline and during tasks were calculated in the theta, 
+      alpha, beta, low gamma, and high gamma bands. The spatial contour plots reveal that 
+      PSDt values during object naming were 10-20% higher than the baseline values for 
+      different bands. Language was lateralized to left frontal or temporal areas. In all 
+      cases, the Wada test disclosed language lateralization to the left hemisphere as 
+      well.
+FAU - Ramon, C
+AU  - Ramon C
+AD  - Department of Electrical Engineering, University of Washington, Seattle, WA 98195, 
+      USA. ceon@u.washington.edu
+FAU - Holmes, M
+AU  - Holmes M
+FAU - Freeman, Walter J
+AU  - Freeman WJ
+FAU - Gratkowski, Maciej
+AU  - Gratkowski M
+FAU - Eriksen, K J
+AU  - Eriksen KJ
+FAU - Haueisen, Jens
+AU  - Haueisen J
+LA  - eng
+PT  - Journal Article
+DEP - 20081101
+PL  - United States
+TA  - Epilepsy Behav
+JT  - Epilepsy & behavior : E&B
+JID - 100892858
+SB  - IM
+MH  - Artifacts
+MH  - Brain/*physiology
+MH  - Brain Mapping
+MH  - Data Interpretation, Statistical
+MH  - *Electroencephalography
+MH  - Epilepsy/*psychology
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - *Language
+MH  - Psycholinguistics
+MH  - Psychomotor Performance/physiology
+MH  - Visual Perception/physiology
+EDAT- 2008/09/16 09:00
+MHDA- 2009/04/21 09:00
+CRDT- 2008/09/16 09:00
+PHST- 2008/03/11 00:00 [received]
+PHST- 2008/07/27 00:00 [revised]
+PHST- 2008/08/22 00:00 [accepted]
+PHST- 2008/09/16 09:00 [pubmed]
+PHST- 2009/04/21 09:00 [medline]
+PHST- 2008/09/16 09:00 [entrez]
+AID - S1525-5050(08)00269-2 [pii]
+AID - 10.1016/j.yebeh.2008.08.018 [doi]
+PST - ppublish
+SO  - Epilepsy Behav. 2009 Jan;14(1):54-9. doi: 10.1016/j.yebeh.2008.08.018. Epub 2008 Nov 
+      1.
+
+PMID- 21722656
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20120131
+LR  - 20151119
+IS  - 1873-3514 (Electronic)
+IS  - 0028-3932 (Linking)
+VI  - 49
+IP  - 10
+DP  - 2011 Aug
+TI  - Magical ideation, creativity, handedness, and cerebral asymmetries: a combined 
+      behavioural and fMRI study.
+PG  - 2896-903
+LID - 10.1016/j.neuropsychologia.2011.06.016 [doi]
+AB  - Magical ideation has been shown to be related to measures of hand preference, in 
+      which those with mixed handedness exhibit higher levels of magical ideation than 
+      those with either consistent left- or right-handedness. It is unclear whether the 
+      relation between magical ideation and hand preference is the result of a bias in 
+      questionnaire-taking behaviour or of some neuropsychological concomitant of cerebral 
+      specialization. We sought to replicate this finding and further investigate how 
+      magical ideation is related to other measures of laterality, including handedness 
+      based on finger-tapping performance, and cerebral asymmetries for language, spatial 
+      judgment, and face processing as revealed by fMRI. Creative achievement was also 
+      assessed by questionnaire and correlated with magical ideation and the other 
+      measures. Magical ideation and creativity were positively correlated, and both were 
+      negatively correlated with absolute hand preference but not with hand performance or 
+      with any of the cerebral asymmetries being assessed. The results do not support the 
+      notion that the observed association between magical ideation, creativity and hand 
+      preference has a neuropsychological explanation based on reduced cerebral 
+      lateralization.
+CI  - Copyright © 2011 Elsevier Ltd. All rights reserved.
+FAU - Badzakova-Trajkov, Gjurgjica
+AU  - Badzakova-Trajkov G
+AD  - Research Centre for Cognitive Neuroscience, Department of Psychology, The University 
+      of Auckland, Auckland, New Zealand. g.badzakova@auckland.ac.nz
+FAU - Häberling, Isabelle S
+AU  - Häberling IS
+FAU - Corballis, Michael C
+AU  - Corballis MC
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20110621
+PL  - England
+TA  - Neuropsychologia
+JT  - Neuropsychologia
+JID - 0020713
+SB  - IM
+MH  - Adolescent
+MH  - Adult
+MH  - Cerebral Cortex/*physiology
+MH  - *Creativity
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - *Hand
+MH  - Humans
+MH  - Magic/*psychology
+MH  - *Magnetic Resonance Imaging
+MH  - Male
+MH  - Middle Aged
+MH  - Neuropsychological Tests
+MH  - Psychomotor Performance
+MH  - Surveys and Questionnaires
+MH  - Thinking
+MH  - Young Adult
+EDAT- 2011/07/05 06:00
+MHDA- 2012/02/01 06:00
+CRDT- 2011/07/05 06:00
+PHST- 2010/08/12 00:00 [received]
+PHST- 2011/06/07 00:00 [revised]
+PHST- 2011/06/14 00:00 [accepted]
+PHST- 2011/07/05 06:00 [entrez]
+PHST- 2011/07/05 06:00 [pubmed]
+PHST- 2012/02/01 06:00 [medline]
+AID - S0028-3932(11)00297-1 [pii]
+AID - 10.1016/j.neuropsychologia.2011.06.016 [doi]
+PST - ppublish
+SO  - Neuropsychologia. 2011 Aug;49(10):2896-903. doi: 
+      10.1016/j.neuropsychologia.2011.06.016. Epub 2011 Jun 21.
+
+PMID- 19045830
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20090123
+LR  - 20181113
+IS  - 1751-8849 (Print)
+IS  - 1751-8849 (Linking)
+VI  - 2
+IP  - 5
+DP  - 2008 Sep
+TI  - Virtual Cell modelling and simulation software environment.
+PG  - 352-62
+LID - 10.1049/iet-syb:20080102 [doi]
+AB  - The Virtual Cell (VCell; http://vcell.org/) is a problem solving environment, built 
+      on a central database, for analysis, modelling and simulation of cell biological 
+      processes. VCell integrates a growing range of molecular mechanisms, including 
+      reaction kinetics, diffusion, flow, membrane transport, lateral membrane diffusion 
+      and electrophysiology, and can associate these with geometries derived from 
+      experimental microscope images. It has been developed and deployed as a web-based, 
+      distributed, client-server system, with more than a thousand world-wide users. VCell 
+      provides a separation of layers (core technologies and abstractions) representing 
+      biological models, physical mechanisms, geometry, mathematical models and numerical 
+      methods. This separation clarifies the impact of modelling decisions, assumptions 
+      and approximations. The result is a physically consistent, mathematically rigorous, 
+      spatial modelling and simulation framework. Users create biological models and VCell 
+      will automatically (i) generate the appropriate mathematical encoding for running a 
+      simulation and (ii) generate and compile the appropriate computer code. Both 
+      deterministic and stochastic algorithms are supported for describing and running 
+      non-spatial simulations; a full partial differential equation solver using the 
+      finite volume numerical algorithm is available for reaction-diffusion-advection 
+      simulations in complex cell geometries including 3D geometries derived from 
+      microscope images. Using the VCell database, models and model components can be 
+      reused and updated, as well as privately shared among collaborating groups, or 
+      published. Exchange of models with other tools is possible via import/export of 
+      SBML, CellML and MatLab formats. Furthermore, curation of models is facilitated by 
+      external database binding mechanisms for unique identification of components and by 
+      standardised annotations compliant with the MIRIAM standard. VCell is now open 
+      source, with its native model encoding language (VCML) being a public specification, 
+      which stands as the basis for a new generation of more customised, 
+      experiment-centric modelling tools using a new plug-in based platform.
+FAU - Moraru, I I
+AU  - Moraru II
+AD  - University of Connecticut Health Center, Center of Cell Analysis and Modeling, 
+      Connecticut, CA 06030, USA.
+FAU - Schaff, J C
+AU  - Schaff JC
+FAU - Slepchenko, B M
+AU  - Slepchenko BM
+FAU - Blinov, M L
+AU  - Blinov ML
+FAU - Morgan, F
+AU  - Morgan F
+FAU - Lakshminarayana, A
+AU  - Lakshminarayana A
+FAU - Gao, F
+AU  - Gao F
+FAU - Li, Y
+AU  - Li Y
+FAU - Loew, L M
+AU  - Loew LM
+LA  - eng
+GR  - U54 GM064346-089032/GM/NIGMS NIH HHS/United States
+GR  - P41RR013186/RR/NCRR NIH HHS/United States
+GR  - P41 RR013186-12/RR/NCRR NIH HHS/United States
+GR  - P41 RR013186/RR/NCRR NIH HHS/United States
+GR  - U54 GM064346/GM/NIGMS NIH HHS/United States
+GR  - U54RR022232/RR/NCRR NIH HHS/United States
+GR  - U54 RR022232-04/RR/NCRR NIH HHS/United States
+GR  - U54 RR022232/RR/NCRR NIH HHS/United States
+PT  - Journal Article
+PT  - Research Support, N.I.H., Extramural
+TA  - IET Syst Biol
+JT  - IET systems biology
+JID - 101301198
+RN  - 0 (Proteome)
+SB  - IM
+MH  - Computer Simulation
+MH  - *Databases, Factual
+MH  - Information Storage and Retrieval/methods
+MH  - *Models, Biological
+MH  - Programming Languages
+MH  - Proteome/*metabolism
+MH  - Signal Transduction/*physiology
+MH  - *Software
+MH  - *User-Computer Interface
+PMC - PMC2711391
+MID - NIHMS121244
+EDAT- 2008/12/03 09:00
+MHDA- 2009/01/24 09:00
+CRDT- 2008/12/03 09:00
+PHST- 2008/12/03 09:00 [pubmed]
+PHST- 2009/01/24 09:00 [medline]
+PHST- 2008/12/03 09:00 [entrez]
+AID - 10.1049/iet-syb:20080102 [doi]
+PST - ppublish
+SO  - IET Syst Biol. 2008 Sep;2(5):352-62. doi: 10.1049/iet-syb:20080102.
+
+PMID- 31220770
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20191125
+LR  - 20191125
+IS  - 1873-6297 (Electronic)
+IS  - 0001-6918 (Linking)
+VI  - 198
+DP  - 2019 Jul
+TI  - A replication attempt of hemispheric differences in semantic-relatedness judgments 
+      (Zwaan & Yaxley, 2003).
+PG  - 102871
+LID - S0001-6918(18)30587-0 [pii]
+LID - 10.1016/j.actpsy.2019.102871 [doi]
+AB  - In a study by Zwaan and Yaxley (2003, Cognition, 87, B79-B86), participants judged 
+      the semantic relatedness of word pairs presented one above the other either in the 
+      left or right visual field with all related pairs requiring right-handed responses. 
+      If the vertical orientation of the word pairs matched their referents' typical 
+      vertical orientation ("roof" above "basement") a match effect was observed, but only 
+      when the word pair was presented in the left visual field. We replicated this study 
+      with response side as an additional factor and found a main effect of match, as well 
+      as a Simon effect with faster responses when the required response matched the 
+      visual field in which the word pair was presented. We did not, however, observe an 
+      interaction between the match effect and the visual field. This challenges the 
+      assumption that coarse semantic representations, including spatial properties of 
+      objects, are mainly processed in the right hemisphere.
+CI  - Copyright © 2019 Elsevier B.V. All rights reserved.
+FAU - Berndt, Eduard
+AU  - Berndt E
+AD  - Department of Psychology, University of Tübingen, Tübingen, Germany. Electronic 
+      address: eduard.berndt@uni-tuebingen.de.
+FAU - Dudschig, Carolin
+AU  - Dudschig C
+AD  - Department of Psychology, University of Tübingen, Tübingen, Germany.
+FAU - Miller, Jeff
+AU  - Miller J
+AD  - Department of Psychology, University of Otago, Dunedin, New Zealand.
+FAU - Kaup, Barbara
+AU  - Kaup B
+AD  - Department of Psychology, University of Tübingen, Tübingen, Germany.
+LA  - eng
+PT  - Journal Article
+DEP - 20190617
+PL  - Netherlands
+TA  - Acta Psychol (Amst)
+JT  - Acta psychologica
+JID - 0370366
+SB  - IM
+MH  - Adolescent
+MH  - Adult
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Judgment/*physiology
+MH  - Male
+MH  - Photic Stimulation/methods
+MH  - Reaction Time/*physiology
+MH  - *Semantics
+MH  - Young Adult
+OTO - NOTNLM
+OT  - Embodied cognition
+OT  - Hemispheric differences
+OT  - Language representation
+EDAT- 2019/06/21 06:00
+MHDA- 2019/11/26 06:00
+CRDT- 2019/06/21 06:00
+PHST- 2018/12/21 00:00 [received]
+PHST- 2019/06/04 00:00 [revised]
+PHST- 2019/06/10 00:00 [accepted]
+PHST- 2019/06/21 06:00 [pubmed]
+PHST- 2019/11/26 06:00 [medline]
+PHST- 2019/06/21 06:00 [entrez]
+AID - S0001-6918(18)30587-0 [pii]
+AID - 10.1016/j.actpsy.2019.102871 [doi]
+PST - ppublish
+SO  - Acta Psychol (Amst). 2019 Jul;198:102871. doi: 10.1016/j.actpsy.2019.102871. Epub 
+      2019 Jun 17.
+
+PMID- 8319079
+OWN - NLM
+STAT- MEDLINE
+DCOM- 19930730
+LR  - 20190914
+IS  - 0093-934X (Print)
+IS  - 0093-934X (Linking)
+VI  - 44
+IP  - 4
+DP  - 1993 May
+TI  - Letters as spatial-oriented shapes and/or graphemic signs: a developmental study of 
+      left- and right-handed girls during the period of learning to read.
+PG  - 385-99
+AB  - This study is concerned with the problem of hemispheric specialization and/or 
+      cooperation in relation to development and manual laterality. The processing of 
+      alphabetic signs and its relationship to interhemispheric transfer and functional 
+      hemispheric asymmetries were studied by comparing left- and right-handed girls 
+      during acquisition of reading. The children perform matching tasks with letters 
+      having different orientations and with meaningless forms having the same 
+      orientations as the letters. Each subject performed the matching under three 
+      conditions: right/left intermanual transfer, left/right intermanual transfer, and 
+      dichaptic exploration. Results indicate: (1) A differentiated development between 
+      the two handednesses. (2) The functional lateralization change was different for 
+      left- and right-handed girls, a greater effect of the ability to identify the letter 
+      on matching tasks was observed for the right-handed children than for the 
+      left-handed children. These last results are discussed with regard to 
+      inter-hemispheric transfer and functional hemispheric asymmetry changes. We 
+      hypothesized a strategy difference between left- and right-handed girls and a 
+      difference in their ability to change their cognitive strategy (left-handers 
+      continue to favor a spatial coding with letters).
+FAU - Benoit-Dubrocard, S
+AU  - Benoit-Dubrocard S
+AD  - Université de Provence, Département de Psychophysiologie, URA-CNRS 372, Centre de St 
+      Jérome, Marseille, France.
+FAU - Touche, M E
+AU  - Touche ME
+LA  - eng
+PT  - Comparative Study
+PT  - Journal Article
+PL  - Netherlands
+TA  - Brain Lang
+JT  - Brain and language
+JID - 7506220
+SB  - IM
+MH  - Brain/physiology
+MH  - Child
+MH  - Child Development/physiology
+MH  - Child Language
+MH  - Child, Preschool
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - *Language
+MH  - Language Tests
+MH  - *Learning
+MH  - *Reading
+EDAT- 1993/05/01 00:00
+MHDA- 1993/05/01 00:01
+CRDT- 1993/05/01 00:00
+PHST- 1993/05/01 00:00 [pubmed]
+PHST- 1993/05/01 00:01 [medline]
+PHST- 1993/05/01 00:00 [entrez]
+AID - S0093934X83710230 [pii]
+AID - 10.1006/brln.1993.1023 [doi]
+PST - ppublish
+SO  - Brain Lang. 1993 May;44(4):385-99. doi: 10.1006/brln.1993.1023.
+
+PMID- 23850599
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20140508
+LR  - 20130924
+IS  - 1873-3514 (Electronic)
+IS  - 0028-3932 (Linking)
+VI  - 51
+IP  - 11
+DP  - 2013 Sep
+TI  - Neglect dyslexia: a matter of "good looking".
+PG  - 2109-19
+LID - S0028-3932(13)00229-7 [pii]
+LID - 10.1016/j.neuropsychologia.2013.07.002 [doi]
+AB  - Brain-damaged patients with right-sided unilateral spatial neglect (USN) often make 
+      left-sided errors in reading single words or pseudowords (neglect dyslexia, ND). We 
+      propose that both left neglect and low fixation accuracy account for reading errors 
+      in neglect dyslexia. Eye movements were recorded in USN patients with (ND+) and 
+      without (ND-) neglect dyslexia and in a matched control group of right brain-damaged 
+      patients without neglect (USN-). Unlike ND- and controls, ND+ patients showed left 
+      lateralized omission errors and a distorted eye movement pattern in both a reading 
+      aloud task and a non-verbal saccadic task. During reading, the total number of 
+      fixations was larger in these patients independent of visual hemispace, and most 
+      fixations were inaccurate. Similarly, in the saccadic task only ND+ patients were 
+      unable to reach the moving dot. A third experiment addressed the nature of the left 
+      lateralization in reading error distribution by simulating neglect dyslexia in ND- 
+      patients. ND- and USN- patients had to perform a speeded reading-at-threshold task 
+      that did not allow for eye movements. When stimulus exploration was prevented, ND- 
+      patients, but not controls, produced a pattern of errors similar to that of ND+ with 
+      unlimited exposure time (e.g., left-sided errors). We conclude that neglect dyslexia 
+      reading errors may arise in USN patients as a consequence of an additional and 
+      independent deficit unrelated to the orthographic material. In particular, the 
+      presence of an altered oculo-motor pattern, preventing the automatic execution of 
+      the fine saccadic eye movements involved in reading, uncovers, in USN patients, the 
+      attentional bias also in reading single centrally presented words.
+CI  - © 2013 Elsevier Ltd. All rights reserved.
+FAU - Primativo, Silvia
+AU  - Primativo S
+AD  - Department of Psychology, Sapienza University of Rome, Via dei Marsi, 78, 00100, 
+      Rome, Italy; Neuropsychology Unit, IRCCS Fondazione Santa Lucia, Via Ardeatina, 306, 
+      00100, Rome, Italy. Electronic address: silvia.primativo@uniroma1.it.
+FAU - Arduino, Lisa S
+AU  - Arduino LS
+FAU - De Luca, Maria
+AU  - De Luca M
+FAU - Daini, Roberta
+AU  - Daini R
+FAU - Martelli, Marialuisa
+AU  - Martelli M
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20130710
+PL  - England
+TA  - Neuropsychologia
+JT  - Neuropsychologia
+JID - 0020713
+SB  - IM
+MH  - Aged
+MH  - Aged, 80 and over
+MH  - Attention/physiology
+MH  - Dyslexia/*physiopathology
+MH  - Eye Movements/*physiology
+MH  - Female
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - Male
+MH  - Middle Aged
+MH  - Perceptual Disorders/*physiopathology
+MH  - *Reading
+MH  - Space Perception/physiology
+MH  - Visual Fields/physiology
+OTO - NOTNLM
+OT  - Eye movements
+OT  - Neglect
+OT  - Neglect dyslexia
+OT  - Reading
+EDAT- 2013/07/16 06:00
+MHDA- 2014/05/09 06:00
+CRDT- 2013/07/16 06:00
+PHST- 2012/12/05 00:00 [received]
+PHST- 2013/06/27 00:00 [revised]
+PHST- 2013/07/01 00:00 [accepted]
+PHST- 2013/07/16 06:00 [entrez]
+PHST- 2013/07/16 06:00 [pubmed]
+PHST- 2014/05/09 06:00 [medline]
+AID - S0028-3932(13)00229-7 [pii]
+AID - 10.1016/j.neuropsychologia.2013.07.002 [doi]
+PST - ppublish
+SO  - Neuropsychologia. 2013 Sep;51(11):2109-19. doi: 
+      10.1016/j.neuropsychologia.2013.07.002. Epub 2013 Jul 10.
+
+PMID- 8862845
+OWN - NLM
+STAT- MEDLINE
+DCOM- 19970106
+LR  - 20190830
+IS  - 0317-1671 (Print)
+IS  - 0317-1671 (Linking)
+VI  - 23
+IP  - 3
+DP  - 1996 Aug
+TI  - Functional MRI localization of language in a 9-year-old child.
+PG  - 213-9
+AB  - BACKGROUND: Localizing critical brain functions such as language in children is 
+      difficult and generally requires invasive techniques. Recently sensory, motor and 
+      language functions in adults have been mapped to specific brain locations using 
+      functional imaging techniques. Of these techniques, functional MRI (fMRI) is the 
+      least invasive and has the highest spatial and temporal resolution. Its use in 
+      adults is well documented but application to children has not been as well 
+      described. In the present study lateralization and localization of language was 
+      evaluated with fMRI prior to epilepsy surgery in a nine-year-old male with complex 
+      partial seizures, attentional difficulty and decreased verbal proficiency. METHODS: 
+      Two language paradigms well studied in adults (read, verb generation) and two 
+      additional language paradigms (antonym generation, latter fluency) were studied 
+      using whole brain fMRI after stimulus items and timing were adjusted to achieve the 
+      desired performance level during imaging. The patient was also conditioned to the 
+      magnet environment prior to imaging. RESULTS: Word reading and letter fluency tasks 
+      produced lateralized and localized activation similar to that seen in adults. The 
+      patient had no language deficits following an anterior 2/3 dominant temporal lobe 
+      resection. CONCLUSIONS: With modifications of protocols such as those detailed in 
+      this report, this non-invasive method for localizing language function is feasible 
+      for the presurgical evaluation of children as well being applicable for a variety of 
+      developmental language issues.
+FAU - Benson, R R
+AU  - Benson RR
+AD  - Department of Neurology, Massachusetts General Hospital, Boston 02129-2060, USA.
+FAU - Logan, W J
+AU  - Logan WJ
+FAU - Cosgrove, G R
+AU  - Cosgrove GR
+FAU - Cole, A J
+AU  - Cole AJ
+FAU - Jiang, H
+AU  - Jiang H
+FAU - LeSueur, L L
+AU  - LeSueur LL
+FAU - Buchbinder, B R
+AU  - Buchbinder BR
+FAU - Rosen, B R
+AU  - Rosen BR
+FAU - Caviness, V S Jr
+AU  - Caviness VS Jr
+LA  - eng
+PT  - Case Reports
+PT  - Journal Article
+PL  - England
+TA  - Can J Neurol Sci
+JT  - The Canadian journal of neurological sciences. Le journal canadien des sciences 
+      neurologiques
+JID - 0415227
+SB  - IM
+MH  - Brain/*physiology
+MH  - Brain Mapping
+MH  - Child
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - *Language
+MH  - Magnetic Resonance Imaging
+MH  - Male
+MH  - Photic Stimulation
+EDAT- 1996/08/01 00:00
+MHDA- 2001/03/28 10:01
+CRDT- 1996/08/01 00:00
+PHST- 1996/08/01 00:00 [pubmed]
+PHST- 2001/03/28 10:01 [medline]
+PHST- 1996/08/01 00:00 [entrez]
+AID - 10.1017/s0317167100038543 [doi]
+PST - ppublish
+SO  - Can J Neurol Sci. 1996 Aug;23(3):213-9. doi: 10.1017/s0317167100038543.
+
+PMID- 20727412
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20110119
+LR  - 20181113
+IS  - 1095-9572 (Electronic)
+IS  - 1053-8119 (Print)
+IS  - 1053-8119 (Linking)
+VI  - 54
+IP  - 1
+DP  - 2011 Jan 1
+TI  - Symbolic representations in motor sequence learning.
+PG  - 417-26
+LID - 10.1016/j.neuroimage.2010.08.019 [doi]
+AB  - It has been shown that varying the spatial versus symbolic nature of stimulus 
+      presentation and response production, which affects stimulus-response (S-R) mapping 
+      requirements, influences the magnitude of implicit sequence learning (Koch and 
+      Hoffman, 2000). Here, we evaluated how spatial and symbolic stimuli and responses 
+      affect the neural bases of sequence learning. We selectively eliminated the spatial 
+      component of stimulus presentation (spatial vs. symbolic), response execution 
+      (manual vs. vocal), or both. Fourteen participants performed the alternating serial 
+      reaction time task under these conditions in an MRI scanner, with interleaved 
+      acquisition to allow for recording of vocal response reaction times. Nine regions of 
+      interest (ROIs) were selected to test the hypothesis that the dorsolateral 
+      prefrontal cortex (DLPFC) was preferentially engaged for spatially cued conditions 
+      and cerebellum lobule HVI, crus I and II were associated with symbolically cued 
+      learning. We found that the left cerebellum lobule HVI was selectively recruited for 
+      symbolic learning and the percent signal change in this region was correlated with 
+      learning magnitude under the symbolic conditions. In contrast, the DLPFC did not 
+      exhibit selective activation for learning under spatial conditions. The inferior 
+      parietal lobule exhibited increased activation during learning regardless of the 
+      condition, supporting its role in forming an abstract representation of learned 
+      sequences. These findings reveal different brain networks that are flexibly engaged 
+      depending on the conditions of sequence learning.
+CI  - Copyright © 2010 Elsevier Inc. All rights reserved.
+FAU - Bo, J
+AU  - Bo J
+AD  - School of Kinesiology, University of Michigan, Ann Arbor, MI 48109-1109, USA.
+FAU - Peltier, S J
+AU  - Peltier SJ
+FAU - Noll, D C
+AU  - Noll DC
+FAU - Seidler, R D
+AU  - Seidler RD
+LA  - eng
+GR  - R01 AG024106/AG/NIA NIH HHS/United States
+GR  - R01 AG024106-04S1/AG/NIA NIH HHS/United States
+GR  - AG024106/AG/NIA NIH HHS/United States
+PT  - Journal Article
+PT  - Research Support, N.I.H., Extramural
+DEP - 20100818
+TA  - Neuroimage
+JT  - NeuroImage
+JID - 9215515
+SB  - IM
+MH  - Adult
+MH  - Brain/*physiology
+MH  - Brain Mapping/methods
+MH  - Cerebellum/*physiology
+MH  - Female
+MH  - Fixation, Ocular/physiology
+MH  - Frontal Lobe/physiology
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - Learning/*physiology
+MH  - Magnetic Resonance Imaging/*methods
+MH  - Male
+MH  - Nerve Net/*physiology
+MH  - Parietal Lobe/physiology
+MH  - Reaction Time/*physiology
+MH  - Sequence Analysis/methods
+MH  - Space Perception
+MH  - Speech
+MH  - Symbolism
+MH  - Young Adult
+PMC - PMC2962690
+MID - NIHMS231449
+EDAT- 2010/08/24 06:00
+MHDA- 2011/01/20 06:00
+CRDT- 2010/08/24 06:00
+PHST- 2010/06/07 00:00 [received]
+PHST- 2010/07/23 00:00 [revised]
+PHST- 2010/08/10 00:00 [accepted]
+PHST- 2010/08/24 06:00 [entrez]
+PHST- 2010/08/24 06:00 [pubmed]
+PHST- 2011/01/20 06:00 [medline]
+AID - S1053-8119(10)01101-8 [pii]
+AID - 10.1016/j.neuroimage.2010.08.019 [doi]
+PST - ppublish
+SO  - Neuroimage. 2011 Jan 1;54(1):417-26. doi: 10.1016/j.neuroimage.2010.08.019. Epub 
+      2010 Aug 18.
+
+PMID- 27001861
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20161213
+LR  - 20181113
+IS  - 1091-6490 (Electronic)
+IS  - 0027-8424 (Print)
+IS  - 0027-8424 (Linking)
+VI  - 113
+IP  - 14
+DP  - 2016 Apr 5
+TI  - Spatiotemporal dynamics of auditory attention synchronize with speech.
+PG  - 3873-8
+LID - 10.1073/pnas.1523357113 [doi]
+AB  - Attention plays a fundamental role in selectively processing stimuli in our 
+      environment despite distraction. Spatial attention induces increasing and decreasing 
+      power of neural alpha oscillations (8-12 Hz) in brain regions ipsilateral and 
+      contralateral to the locus of attention, respectively. This study tested whether the 
+      hemispheric lateralization of alpha power codes not just the spatial location but 
+      also the temporal structure of the stimulus. Participants attended to spoken digits 
+      presented to one ear and ignored tightly synchronized distracting digits presented 
+      to the other ear. In the magnetoencephalogram, spatial attention induced 
+      lateralization of alpha power in parietal, but notably also in auditory cortical 
+      regions. This alpha power lateralization was not maintained steadily but fluctuated 
+      in synchrony with the speech rate and lagged the time course of low-frequency (1-5 
+      Hz) sensory synchronization. Higher amplitude of alpha power modulation at the 
+      speech rate was predictive of a listener's enhanced performance of stream-specific 
+      speech comprehension. Our findings demonstrate that alpha power lateralization is 
+      modulated in tune with the sensory input and acts as a spatiotemporal filter 
+      controlling the read-out of sensory content.
+FAU - Wöstmann, Malte
+AU  - Wöstmann M
+AD  - Department of Psychology, University of Lübeck, 23562 Luebeck, Germany; Max Planck 
+      Research Group "Auditory Cognition," Max Planck Institute for Human Cognitive and 
+      Brain Sciences, 04103 Leipzig, Germany; malte.woestmann@uni-luebeck.de 
+      jonas.obleser@uni-luebeck.de.
+FAU - Herrmann, Björn
+AU  - Herrmann B
+AD  - Max Planck Research Group "Auditory Cognition," Max Planck Institute for Human 
+      Cognitive and Brain Sciences, 04103 Leipzig, Germany; Department of Psychology, The 
+      University of Western Ontario, London, Canada N6A 5C2;
+FAU - Maess, Burkhard
+AU  - Maess B
+AD  - Magnetoencephalography and Cortical Networks Unit, Max Planck Institute for Human 
+      Cognitive and Brain Sciences, 04103 Leipzig, Germany.
+FAU - Obleser, Jonas
+AU  - Obleser J
+AUID- ORCID: 0000-0002-7619-0459
+AD  - Department of Psychology, University of Lübeck, 23562 Luebeck, Germany; Max Planck 
+      Research Group "Auditory Cognition," Max Planck Institute for Human Cognitive and 
+      Brain Sciences, 04103 Leipzig, Germany; malte.woestmann@uni-luebeck.de 
+      jonas.obleser@uni-luebeck.de.
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20160321
+TA  - Proc Natl Acad Sci U S A
+JT  - Proceedings of the National Academy of Sciences of the United States of America
+JID - 7505876
+SB  - IM
+MH  - Acoustic Stimulation
+MH  - Adult
+MH  - Attention/*physiology
+MH  - Auditory Cortex/physiology
+MH  - Auditory Perception/*physiology
+MH  - Brain Mapping
+MH  - Brain Waves/*physiology
+MH  - Female
+MH  - Functional Laterality/physiology
+MH  - Hearing/*physiology
+MH  - Humans
+MH  - Magnetoencephalography
+MH  - Male
+MH  - Reaction Time
+MH  - Spatial Behavior/physiology
+MH  - *Spatio-Temporal Analysis
+MH  - Speech/*physiology
+MH  - Speech Perception/*physiology
+MH  - Young Adult
+PMC - PMC4833226
+OTO - NOTNLM
+OT  - alpha lateralization
+OT  - attention
+OT  - neural oscillations
+OT  - speech
+OT  - synchronization
+COIS- The authors declare no conflict of interest.
+EDAT- 2016/03/24 06:00
+MHDA- 2016/12/15 06:00
+CRDT- 2016/03/23 06:00
+PHST- 2016/03/23 06:00 [entrez]
+PHST- 2016/03/24 06:00 [pubmed]
+PHST- 2016/12/15 06:00 [medline]
+AID - 1523357113 [pii]
+AID - 201523357 [pii]
+AID - 10.1073/pnas.1523357113 [doi]
+PST - ppublish
+SO  - Proc Natl Acad Sci U S A. 2016 Apr 5;113(14):3873-8. doi: 10.1073/pnas.1523357113. 
+      Epub 2016 Mar 21.
+
+PMID- 23142349
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20130625
+LR  - 20130111
+IS  - 1873-3514 (Electronic)
+IS  - 0028-3932 (Linking)
+VI  - 51
+IP  - 1
+DP  - 2013 Jan
+TI  - Line bisection error predicts the presence and severity of neglect dyslexia in 
+      paragraph reading.
+PG  - 1-7
+LID - S0028-3932(12)00464-2 [pii]
+LID - 10.1016/j.neuropsychologia.2012.10.026 [doi]
+AB  - Cancellation tasks and line bisection tasks are commonly used to diagnose spatial 
+      neglect after right hemisphere lesions. In such tasks, neglect patients often show 
+      leftsided omissions of targets in cancellation tests as well as a pathological 
+      rightward deviation in horizontal line bisection. However, double dissociations have 
+      also been reported and the relation between performance in both tasks is not clear. 
+      Another impairment frequently associated with the neglect syndrome are omissions or 
+      misread initial letters of single words, a phenomenon termed neglect dyslexia (ND). 
+      Omissions of whole words on the contralesional side of the page are generally 
+      considered as egocentric or space-based errors, whereas misreadings of the left part 
+      of a word in ND can be viewed as a type of stimulus-centered or word-based, 
+      perceptual error. As words, sentences and horizontal lines have a similar spatial 
+      layout in the sense that they all are horizontally aligned, long stimuli with a 
+      canonical left-right orientation (with a defined beginning on the left and an end on 
+      the right side), we hypothesized a significant association between the horizontal 
+      line bisection error (LBE) in neglect and the extent (number) of neglected or 
+      substituted letters within single words in ND (neglect dyslexia extension, NDE). To 
+      this purpose, we computed Center-of-Cancellation (CoC) scores in a cancellation task 
+      as well as Center-of-Reading (CoR) scores in an experimental paragraph reading test. 
+      We found that the CoR was a better indicator for egocentric word omissions than the 
+      CoC in a group of 17 patients with left visuospatial neglect. Furthermore, the LBE 
+      predicted the severity of ND, indicated by highly significant correlations between 
+      the LBE and the extent of the neglected letter string within single words (NDE; 
+      r=0.73, p<0.001) as well as between the LBE and the frequency of ND errors (r=0.61; 
+      p=0.009). In contrast, we found no significant correlation between the CoC and the 
+      severity of ND. These results indicate two different pathological mechanisms being 
+      responsible for contralesional spatial neglect and ND. In conclusion, the LBE is a 
+      more sensitive predictor of the presence and severity of the reading disorder in 
+      spatial neglect than conventional cancellation tasks.
+CI  - Copyright © 2012 Elsevier Ltd. All rights reserved.
+FAU - Reinhart, Stefan
+AU  - Reinhart S
+AD  - Saarland University, Clinical Neuropsychology Unit and Outpatient Service, 
+      Saarbrücken, Germany. s.reinhart@mx.uni-saarland.de
+FAU - Wagner, Prisca
+AU  - Wagner P
+FAU - Schulz, Anna
+AU  - Schulz A
+FAU - Keller, Ingo
+AU  - Keller I
+FAU - Kerkhoff, Georg
+AU  - Kerkhoff G
+LA  - eng
+PT  - Journal Article
+DEP - 20121107
+PL  - England
+TA  - Neuropsychologia
+JT  - Neuropsychologia
+JID - 0020713
+SB  - IM
+MH  - Aged
+MH  - Dyslexia/*complications
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Male
+MH  - Middle Aged
+MH  - Perceptual Disorders/*complications
+MH  - Predictive Value of Tests
+MH  - *Reading
+MH  - Space Perception/physiology
+MH  - Statistics as Topic
+EDAT- 2012/11/13 06:00
+MHDA- 2013/06/26 06:00
+CRDT- 2012/11/13 06:00
+PHST- 2012/06/21 00:00 [received]
+PHST- 2012/10/08 00:00 [revised]
+PHST- 2012/10/30 00:00 [accepted]
+PHST- 2012/11/13 06:00 [entrez]
+PHST- 2012/11/13 06:00 [pubmed]
+PHST- 2013/06/26 06:00 [medline]
+AID - S0028-3932(12)00464-2 [pii]
+AID - 10.1016/j.neuropsychologia.2012.10.026 [doi]
+PST - ppublish
+SO  - Neuropsychologia. 2013 Jan;51(1):1-7. doi: 10.1016/j.neuropsychologia.2012.10.026. 
+      Epub 2012 Nov 7.
+
+PMID- 26011744
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20160218
+LR  - 20181202
+IS  - 1090-2155 (Electronic)
+IS  - 0093-934X (Linking)
+VI  - 147
+DP  - 2015 Aug
+TI  - Right unilateral spatial neglect in aphasic patients.
+PG  - 21-9
+LID - S0093-934X(15)00103-0 [pii]
+LID - 10.1016/j.bandl.2015.05.001 [doi]
+AB  - To investigate spatial responses by aphasic patients during language tasks, 63 
+      aphasics (21 severe, 21 moderate, and 21 mild) were administered two kinds of 
+      auditory pointing tasks-word tasks and sentence tasks-in which the spatial 
+      conditions of the stimuli were controlled. There were significantly fewer correct 
+      responses on the right side of a space than on the left side in both the word and 
+      sentence tasks, but the left deviation of correct responses was more prominent in 
+      the sentence task than in the word task. Additionally, the severe aphasics exhibited 
+      a prominent leftward deviation that may have been the result of deficits in 
+      rightward attention controlled by the left hemisphere. This phenomenon also seems to 
+      reflect the directional attention that is subserved by the right hemisphere, which 
+      attends to the left side of a space and, less predominantly, the right side of a 
+      space.
+CI  - Copyright © 2015 Elsevier Inc. All rights reserved.
+FAU - Ihori, Nami
+AU  - Ihori N
+AD  - Department of Rehabilitation, Kawasaki Cooperative Hospital, 2-1-5 Sakuramoto, 
+      Kawasaki-ku, Kawasaki 210-0833, Japan. Electronic address: ihorinami@aol.com.
+FAU - Kashiwagi, Asako
+AU  - Kashiwagi A
+AD  - Department of Rehabilitation, Kyoritsu Rehabilitation Hospital, 1-39-1 Hirano, 
+      Kawanishi 666-0121, Japan.
+FAU - Kashiwagi, Toshihiro
+AU  - Kashiwagi T
+AD  - Department of Rehabilitation, Nakaya Hospital, 123-1 Narukami, Wakayama 640-8303, 
+      Japan.
+LA  - eng
+PT  - Journal Article
+DEP - 20150523
+PL  - Netherlands
+TA  - Brain Lang
+JT  - Brain and language
+JID - 7506220
+SB  - IM
+MH  - Adult
+MH  - Aged
+MH  - Aged, 80 and over
+MH  - Aphasia/*complications/*physiopathology
+MH  - Attention/physiology
+MH  - Female
+MH  - *Functional Laterality
+MH  - Humans
+MH  - *Language
+MH  - Male
+MH  - Middle Aged
+MH  - Perceptual Disorders/*complications/*physiopathology
+MH  - Vocabulary
+OTO - NOTNLM
+OT  - Aphasic patients
+OT  - Directional attention
+OT  - Language task
+OT  - Left brain damage
+OT  - Leftward deviation
+OT  - Mild aphasia
+OT  - Moderate aphasia
+OT  - Right unilateral spatial neglect
+OT  - Severe aphasia
+EDAT- 2015/05/27 06:00
+MHDA- 2016/02/19 06:00
+CRDT- 2015/05/27 06:00
+PHST- 2014/09/07 00:00 [received]
+PHST- 2015/04/16 00:00 [revised]
+PHST- 2015/05/02 00:00 [accepted]
+PHST- 2015/05/27 06:00 [entrez]
+PHST- 2015/05/27 06:00 [pubmed]
+PHST- 2016/02/19 06:00 [medline]
+AID - S0093-934X(15)00103-0 [pii]
+AID - 10.1016/j.bandl.2015.05.001 [doi]
+PST - ppublish
+SO  - Brain Lang. 2015 Aug;147:21-9. doi: 10.1016/j.bandl.2015.05.001. Epub 2015 May 23.
+
+PMID- 24939724
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20150330
+LR  - 20160511
+IS  - 2158-0022 (Electronic)
+IS  - 2158-0014 (Linking)
+VI  - 4
+IP  - 6
+DP  - 2014 Aug
+TI  - The presupplementary area within the language network: a resting state functional 
+      magnetic resonance imaging functional connectivity analysis.
+PG  - 440-53
+LID - 10.1089/brain.2014.0263 [doi]
+AB  - The presupplementary motor area (pre-SMA) is involved in volitional selection. 
+      Despite the lateralization of the language network and different functions for both 
+      pre-SMA, few studies have reported the lateralization of pre-SMA activity and very 
+      little is known about the possible lateralization of pre-SMA connectivity. Via 
+      functional connectivity analysis, we sought to understand how the language network 
+      may be connected to other intrinsic connectivity networks (ICNs) through the 
+      pre-SMA. We performed a spatial independent component analysis of resting state 
+      functional magnetic resonance imaging in 30 volunteers to identify the language 
+      network. Subsequently, we applied seed-to-voxel functional connectivity analyses 
+      centered on peaks detected in the pre-SMA. Three signal peaks were detected in the 
+      pre-SMA. The left rostral pre-SMA intrinsic connectivity network (LR ICN) was left 
+      lateralized in contrast to bilateral ICNs associated to right pre-SMA peaks. The LR 
+      ICN was anticorrelated with the dorsal attention network and the right caudal 
+      pre-SMA ICN (RC ICN) anticorrelated with the default mode network. These two ICNs 
+      overlapped minimally. In contrast, the right rostral ICN overlapped the LR ICN. Both 
+      right ICNs overlapped in the ventral attention network (vATT). The bilateral 
+      connectivity of the right rostral pre-SMA may allow right hemispheric recruitment to 
+      process semantic ambiguities. Overlap between the right pre-SMA ICNs in vATT may 
+      contribute to internal thought to external environment reorientation. Distinct ICNs 
+      connected to areas involved in lexico-syntactic selection and phonology converge in 
+      the pre-SMA, which may constitute the resolution space of competing condition-action 
+      associations for speech production.
+FAU - Ter Minassian, Aram
+AU  - Ter Minassian A
+AD  - 1 Laboratoire Angevin de Recherche en Ingénierie des Systèmes (LARIS) , Équipe 
+      Information, Signal, Image et Sciences du Vivant (ISISV), Université d'Angers, 
+      Angers, France .
+FAU - Ricalens, Emmanuel
+AU  - Ricalens E
+FAU - Nguyen The Tich, Sylvie
+AU  - Nguyen The Tich S
+FAU - Dinomais, Mickaël
+AU  - Dinomais M
+FAU - Aubé, Christophe
+AU  - Aubé C
+FAU - Beydon, Laurent
+AU  - Beydon L
+LA  - eng
+PT  - Journal Article
+DEP - 20140722
+PL  - United States
+TA  - Brain Connect
+JT  - Brain connectivity
+JID - 101550313
+SB  - IM
+MH  - Adult
+MH  - Attention/physiology
+MH  - Brain/*physiology
+MH  - Brain Mapping
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - *Language
+MH  - Magnetic Resonance Imaging
+MH  - Male
+MH  - Middle Aged
+MH  - Motor Cortex/*physiology
+MH  - Nerve Net/*physiology
+OTO - NOTNLM
+OT  - brain
+OT  - functional connectivity
+OT  - language
+OT  - presupplementary motor area
+OT  - resting state fMRI
+EDAT- 2014/06/19 06:00
+MHDA- 2015/03/31 06:00
+CRDT- 2014/06/19 06:00
+PHST- 2014/06/19 06:00 [entrez]
+PHST- 2014/06/19 06:00 [pubmed]
+PHST- 2015/03/31 06:00 [medline]
+AID - 10.1089/brain.2014.0263 [doi]
+PST - ppublish
+SO  - Brain Connect. 2014 Aug;4(6):440-53. doi: 10.1089/brain.2014.0263. Epub 2014 Jul 22.
+
+PMID- 7960468
+OWN - NLM
+STAT- MEDLINE
+DCOM- 19941205
+LR  - 20190830
+IS  - 0020-7454 (Print)
+IS  - 0020-7454 (Linking)
+VI  - 76
+IP  - 1-2
+DP  - 1994 May
+TI  - Spatial alexia.
+PG  - 49-59
+AB  - Twenty-one patients with right hemisphere damage were studied (11 men, 10 women; 
+      average age = 41.33; range = 19-65). Patients were divided in two groups: 
+      pre-Rolandic (six patients) and retro-Rolandic (15 patients) right hemisphere 
+      damage. A special reading test was given to each patient. The observed errors 
+      included: literal errors (substitutions, additions, and omissions of letters), 
+      substitutions of syllables and pseudowords for meaningful words, left hemispatial 
+      neglect, confabulation, splitting of words, verbal errors (substitutions, additions, 
+      and omission of words), grouping of letters belonging to two different words, misuse 
+      of punctuation marks, and errors in following lines. It was proposed that spatial 
+      alexia is characterized by: (1) some difficulties in the recognition of the spatial 
+      orientation in letters; (2) left hemispatial neglect; (3) tendency to "complete" the 
+      sense of words and sentences; (4) inability to follow lines when reading texts, and 
+      sequentially explore the spatial distribution of the written material; and (5) 
+      grouping and fragmentation of words, most likely as a consequence of the inability 
+      to interpret the relative value of spaces between letters correctly.
+FAU - Ardila, A
+AU  - Ardila A
+AD  - Instituto Colombiano de Neuropsicologia, Bogota.
+FAU - Rosselli, M
+AU  - Rosselli M
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+PL  - England
+TA  - Int J Neurosci
+JT  - The International journal of neuroscience
+JID - 0270707
+SB  - IM
+MH  - Adult
+MH  - Aged
+MH  - Attention
+MH  - Brain Diseases/complications/*diagnosis/physiopathology
+MH  - Colombia/ethnology
+MH  - Dyslexia, Acquired/*diagnosis/etiology/physiopathology
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Language
+MH  - Male
+MH  - Middle Aged
+MH  - Neuropsychological Tests
+MH  - Perceptual Disorders/etiology/physiopathology
+MH  - *Space Perception
+MH  - Spain
+EDAT- 1994/05/01 00:00
+MHDA- 1994/05/01 00:01
+CRDT- 1994/05/01 00:00
+PHST- 1994/05/01 00:00 [pubmed]
+PHST- 1994/05/01 00:01 [medline]
+PHST- 1994/05/01 00:00 [entrez]
+AID - 10.3109/00207459408985991 [doi]
+PST - ppublish
+SO  - Int J Neurosci. 1994 May;76(1-2):49-59. doi: 10.3109/00207459408985991.
+
+PMID- 23921095
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20140625
+LR  - 20131101
+IS  - 1095-9572 (Electronic)
+IS  - 1053-8119 (Linking)
+VI  - 83
+DP  - 2013 Dec
+TI  - Structural white matter asymmetries in relation to functional asymmetries during 
+      speech perception and production.
+PG  - 1088-97
+LID - S1053-8119(13)00845-8 [pii]
+LID - 10.1016/j.neuroimage.2013.07.076 [doi]
+AB  - Functional hemispheric asymmetries of speech production and perception are a key 
+      feature of the human language system, but their neurophysiological basis is still 
+      poorly understood. Using a combined fMRI and tract-based spatial statistics 
+      approach, we investigated the relation of microstructural asymmetries in 
+      language-relevant white matter pathways and functional activation asymmetries during 
+      silent verb generation and passive listening to spoken words. Tract-based spatial 
+      statistics revealed several leftward asymmetric clusters in the arcuate fasciculus 
+      and uncinate fasciculus that were differentially related to activation asymmetries 
+      in the two functional tasks. Frontal and temporal activation asymmetries during 
+      silent verb generation were positively related to the strength of specific 
+      microstructural white matter asymmetries in the arcuate fasciculus. In contrast, 
+      microstructural uncinate fasciculus asymmetries were related to temporal activation 
+      asymmetries during passive listening. These findings suggest that white matter 
+      asymmetries may indeed be one of the factors underlying functional hemispheric 
+      asymmetries. Moreover, they also show that specific localized white matter 
+      asymmetries might be of greater relevance for functional activation asymmetries than 
+      microstructural features of whole pathways.
+CI  - © 2013.
+FAU - Ocklenburg, Sebastian
+AU  - Ocklenburg S
+AD  - Department of Biological and Medical Psychology, University of Bergen, Bergen, 
+      Norway. Electronic address: sebastian.ocklenburg@rub.de.
+FAU - Hugdahl, Kenneth
+AU  - Hugdahl K
+FAU - Westerhausen, René
+AU  - Westerhausen R
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20130803
+PL  - United States
+TA  - Neuroimage
+JT  - NeuroImage
+JID - 9215515
+SB  - IM
+MH  - Adolescent
+MH  - Adult
+MH  - Brain/*cytology/physiology
+MH  - Brain Mapping
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Image Processing, Computer-Assisted
+MH  - Magnetic Resonance Imaging
+MH  - Male
+MH  - Nerve Fibers, Myelinated/physiology/*ultrastructure
+MH  - Speech/*physiology
+MH  - Speech Perception/*physiology
+MH  - Young Adult
+OTO - NOTNLM
+OT  - Arcuate fasciculus
+OT  - Diffusion tensor tractography
+OT  - Functional hemispheric asymmetries
+OT  - Structural hemispheric asymmetries
+OT  - Tract-based spatial statistics
+OT  - Uncinate fasciculus
+EDAT- 2013/08/08 06:00
+MHDA- 2014/06/26 06:00
+CRDT- 2013/08/08 06:00
+PHST- 2013/03/01 00:00 [received]
+PHST- 2013/07/04 00:00 [revised]
+PHST- 2013/07/28 00:00 [accepted]
+PHST- 2013/08/08 06:00 [entrez]
+PHST- 2013/08/08 06:00 [pubmed]
+PHST- 2014/06/26 06:00 [medline]
+AID - S1053-8119(13)00845-8 [pii]
+AID - 10.1016/j.neuroimage.2013.07.076 [doi]
+PST - ppublish
+SO  - Neuroimage. 2013 Dec;83:1088-97. doi: 10.1016/j.neuroimage.2013.07.076. Epub 2013 
+      Aug 3.
+
+PMID- 21429649
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20110912
+LR  - 20110517
+IS  - 1090-2147 (Electronic)
+IS  - 0278-2626 (Linking)
+VI  - 76
+IP  - 2
+DP  - 2011 Jul
+TI  - Effects of attention on dichotic listening in elderly and patients with dementia of 
+      the Alzheimer type.
+PG  - 286-93
+LID - 10.1016/j.bandc.2011.02.008 [doi]
+AB  - This article presents an overview of our studies in elderly and Alzheimer patients 
+      employing Kimura's dichotic digits paradigm as a measure for left hemispheric 
+      predominance for processing language stimuli. In addition to structural brain 
+      mechanisms, we demonstrated that attention modulates the direction and degree of ear 
+      asymmetry in dichotic listening. Elderly showed increasingly more difficulties 
+      focusing attention on the left ear (LE) with advancing age. Alzheimer patients 
+      showed severe deficits to allocate attention to the LE, which could result in a 
+      right ear advantage. These results may be attributed to a breakdown of the cortical 
+      attentional network which is mediated by frontal (inhibitory control of attention) 
+      and parietal regions (spatial attention and 'disengagement processes'). Both 
+      interhemispheric disconnectivity (callosal atrophy) and intrahemispheric 
+      disconnectivity (subcortical white matter lesions) appear to be important factors 
+      contributing to these findings.
+CI  - 2011 Elsevier Inc. All rights reserved.
+FAU - Bouma, Anke
+AU  - Bouma A
+AD  - Department of Clinical and Developmental Neuropsychology, University of Groningen, 
+      Grote Kruisstraat 2/1, 9712 TS Groningen, The Netherlands. j.m.bouma@rug.nl
+FAU - Gootjes, Liselotte
+AU  - Gootjes L
+LA  - eng
+PT  - Journal Article
+PT  - Review
+DEP - 20110322
+PL  - United States
+TA  - Brain Cogn
+JT  - Brain and cognition
+JID - 8218014
+SB  - IM
+MH  - Aged
+MH  - Aged, 80 and over
+MH  - Aging/*physiology
+MH  - Alzheimer Disease/*physiopathology
+MH  - Attention/*physiology
+MH  - Auditory Perception/*physiology
+MH  - Dichotic Listening Tests
+MH  - Functional Laterality/*physiology
+MH  - Humans
+EDAT- 2011/03/25 06:00
+MHDA- 2011/09/13 06:00
+CRDT- 2011/03/25 06:00
+PHST- 2010/12/30 00:00 [received]
+PHST- 2011/02/18 00:00 [revised]
+PHST- 2011/02/18 00:00 [accepted]
+PHST- 2011/03/25 06:00 [entrez]
+PHST- 2011/03/25 06:00 [pubmed]
+PHST- 2011/09/13 06:00 [medline]
+AID - S0278-2626(11)00038-8 [pii]
+AID - 10.1016/j.bandc.2011.02.008 [doi]
+PST - ppublish
+SO  - Brain Cogn. 2011 Jul;76(2):286-93. doi: 10.1016/j.bandc.2011.02.008. Epub 2011 Mar 
+      22.
+
+PMID- 21377668
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20120821
+LR  - 20150708
+IS  - 1973-8102 (Electronic)
+IS  - 0010-9452 (Linking)
+VI  - 48
+IP  - 6
+DP  - 2012 Jun
+TI  - Attention networks and their interactions after right-hemisphere damage.
+PG  - 654-63
+LID - 10.1016/j.cortex.2011.01.009 [doi]
+AB  - Unilateral spatial neglect is a disabling condition, frequently observed after 
+      right-hemisphere damage (RHD), and associated with poor functional recovery. 
+      Clinical and experimental evidence indicates that attentional impairments are 
+      prominent in neglect. Recent brain imaging and behavioral studies in neglect 
+      patients and healthy individuals have provided insights into the mechanisms of 
+      attention and have revealed interactions between putative attentional networks. We 
+      recruited 16 RHD patients and 16 neurologically intact observers to perform a 
+      lateralized version of the Attention Network Test devised by Posner and co-workers 
+      (Fan et al., 2002). The results showed evidence of interaction between attentional 
+      networks during conflict resolution. Phasic alertness improved the orienting deficit 
+      to left-sided targets, reducing the interference of distracters in the neglected 
+      visual field, thus facilitating conflict resolution in the majority of patients. 
+      Modulating alertness may be an important way of improving basic deficits associated 
+      with neglect, such as those affecting spatial orienting.
+CI  - Copyright © 2011 Elsevier Srl. All rights reserved.
+FAU - Chica, Ana B
+AU  - Chica AB
+AD  - INSERM-U975, Centre de Recherche de l'Institut du Cerveau et de la Moëlle Epinière, 
+      Université Pierre et Marie Curie, Groupe Hospitalier Pitié-Salpêtrière, Paris, 
+      France. anachica@ugr.es
+FAU - Thiebaut de Schotten, Michel
+AU  - Thiebaut de Schotten M
+FAU - Toba, Monica
+AU  - Toba M
+FAU - Malhotra, Paresh
+AU  - Malhotra P
+FAU - Lupiáñez, Juan
+AU  - Lupiáñez J
+FAU - Bartolomeo, Paolo
+AU  - Bartolomeo P
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20110203
+PL  - Italy
+TA  - Cortex
+JT  - Cortex; a journal devoted to the study of the nervous system and behavior
+JID - 0100725
+SB  - IM
+MH  - Adult
+MH  - Aged
+MH  - Attention/*physiology
+MH  - Cues
+MH  - Educational Status
+MH  - Female
+MH  - Fixation, Ocular
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Magnetic Resonance Imaging
+MH  - Male
+MH  - Middle Aged
+MH  - Nerve Net/pathology/*physiopathology
+MH  - Neuropsychological Tests
+MH  - Orientation
+MH  - Perceptual Disorders/pathology/*physiopathology/psychology
+MH  - Psychomotor Performance/physiology
+MH  - Reaction Time/physiology
+MH  - Reading
+MH  - Tomography, X-Ray Computed
+EDAT- 2011/03/08 06:00
+MHDA- 2012/08/22 06:00
+CRDT- 2011/03/08 06:00
+PHST- 2010/09/03 00:00 [received]
+PHST- 2010/12/14 00:00 [revised]
+PHST- 2011/01/17 00:00 [accepted]
+PHST- 2011/03/08 06:00 [entrez]
+PHST- 2011/03/08 06:00 [pubmed]
+PHST- 2012/08/22 06:00 [medline]
+AID - S0010-9452(11)00023-2 [pii]
+AID - 10.1016/j.cortex.2011.01.009 [doi]
+PST - ppublish
+SO  - Cortex. 2012 Jun;48(6):654-63. doi: 10.1016/j.cortex.2011.01.009. Epub 2011 Feb 3.
+
+PMID- 29878073
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20191010
+LR  - 20191010
+IS  - 1460-2199 (Electronic)
+IS  - 1047-3211 (Print)
+IS  - 1047-3211 (Linking)
+VI  - 28
+IP  - 8
+DP  - 2018 Aug 1
+TI  - The Ventral Anterior Temporal Lobe has a Necessary Role in Exception Word Reading.
+PG  - 3035-3045
+LID - 10.1093/cercor/bhy131 [doi]
+AB  - An influential account of reading holds that words with exceptional 
+      spelling-to-sound correspondences (e.g., PINT) are read via activation of their 
+      lexical-semantic representations, supported by the anterior temporal lobe (ATL). 
+      This account has been inconclusive because it is based on neuropsychological 
+      evidence, in which lesion-deficit relationships are difficult to localize precisely, 
+      and functional neuroimaging data, which is spatially precise but cannot demonstrate 
+      whether the ATL activity is necessary for exception word reading. To address these 
+      issues, we used a technique with good spatial specificity-repetitive transcranial 
+      magnetic stimulation (rTMS)-to demonstrate a necessary role of ATL in exception word 
+      reading. Following rTMS to left ventral ATL, healthy Japanese adults made more 
+      regularization errors in reading Japanese exception words. We successfully simulated 
+      these results in a computational model in which exception word reading was 
+      underpinned by semantic activations. The ATL is critically and selectively involved 
+      in reading exception words.
+FAU - Ueno, Taiji
+AU  - Ueno T
+AD  - School of Psychology & Clinical Language Sciences, Centre for Integrative 
+      Neuroscience and Neurodynamics, University of Reading, UK.
+AD  - Faculty of Human Sciences, Takachiho University, Tokyo, Japan.
+AD  - Faculty of Environmental Studies, Nagoya University, Nagoya, Japan.
+FAU - Meteyard, Lotte
+AU  - Meteyard L
+AD  - School of Psychology & Clinical Language Sciences, Centre for Integrative 
+      Neuroscience and Neurodynamics, University of Reading, UK.
+FAU - Hoffman, Paul
+AU  - Hoffman P
+AD  - Centre for Cognitive Ageing and Cognitive Epidemiology (CCACE), Department of 
+      Psychology, University of Edinburgh, Edinburgh, UK.
+FAU - Murayama, Kou
+AU  - Murayama K
+AD  - School of Psychology & Clinical Language Sciences, Centre for Integrative 
+      Neuroscience and Neurodynamics, University of Reading, UK.
+AD  - Kochi University of Technology, Kami, Japan.
+AD  - Hector Research Institute of Education Sciences and Psychology, University of 
+      Tübingen, Tübingen, Germany.
+LA  - eng
+GR  - MR/K026992/1/Medical Research Council/United Kingdom
+GR  - Biotechnology and Biological Sciences Research Council/United Kingdom
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+TA  - Cereb Cortex
+JT  - Cerebral cortex (New York, N.Y. : 1991)
+JID - 9110718
+SB  - IM
+MH  - Adult
+MH  - Brain Mapping
+MH  - Computer Simulation
+MH  - Female
+MH  - Functional Laterality
+MH  - Humans
+MH  - Magnetic Resonance Imaging
+MH  - Male
+MH  - Models, Neurological
+MH  - Random Allocation
+MH  - Reaction Time
+MH  - *Reading
+MH  - *Semantics
+MH  - Temporal Lobe/diagnostic imaging/*physiology
+MH  - Transcranial Magnetic Stimulation
+MH  - United Kingdom
+MH  - Verbal Learning
+MH  - *Vocabulary
+PMC - PMC6041960
+EDAT- 2018/06/08 06:00
+MHDA- 2019/10/11 06:00
+CRDT- 2018/06/08 06:00
+PHST- 2017/10/13 00:00 [received]
+PHST- 2018/05/13 00:00 [accepted]
+PHST- 2018/06/08 06:00 [pubmed]
+PHST- 2019/10/11 06:00 [medline]
+PHST- 2018/06/08 06:00 [entrez]
+AID - 5033553 [pii]
+AID - bhy131 [pii]
+AID - 10.1093/cercor/bhy131 [doi]
+PST - ppublish
+SO  - Cereb Cortex. 2018 Aug 1;28(8):3035-3045. doi: 10.1093/cercor/bhy131.
+
+PMID- 21381826
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20110701
+LR  - 20191210
+IS  - 1931-1559 (Electronic)
+IS  - 0894-4105 (Linking)
+VI  - 25
+IP  - 2
+DP  - 2011 Mar
+TI  - Time perception in spatial neglect: a distorted representation?
+PG  - 193-200
+LID - 10.1037/a0021304 [doi]
+AB  - OBJECTIVE: It has been proposed that time, space, and numbers share the same metrics 
+      and cortical network, the right parietal cortex. Several recent investigations have 
+      demonstrated that the mental number line representation is distorted in neglect 
+      patients. The aim of this study is to investigate the relationship between time and 
+      spatial configuration in neglect patients. METHOD: Fourteen right-brain damaged 
+      patients (six with neglect and eight without neglect), as well as eight age-matched 
+      healthy controls, performed a time discrimination task. A standard tone (short: 700 
+      ms and long: 1,700 ms) had to be confronted in duration to a test tone. Test tone 
+      differed of 100, 200, and 300 ms respect to the standard tone duration. RESULTS: 
+      Neglect patients performed significantly worse than patients without neglect and 
+      healthy controls, irrespective of the duration of the standard tone. CONCLUSION: 
+      These results support the hypothesis that mental representations of space and time 
+      both share, to some extent, a common cortical network. Besides, spatial neglect 
+      seems to distort the time representation, inducing an overestimation of time 
+      durations.
+CI  - (c) 2011 APA, all rights reserved
+FAU - Calabria, Marco
+AU  - Calabria M
+AD  - IRCCS Centro San Giovanni di Dio Fatebenefratelli, Via PILASTRONI, 4; 25125 Brescia, 
+      Italy. calabria.marc@gmail.com
+FAU - Jacquin-Courtois, Sophie
+AU  - Jacquin-Courtois S
+FAU - Miozzo, Antonio
+AU  - Miozzo A
+FAU - Rossetti, Yves
+AU  - Rossetti Y
+FAU - Padovani, Alessandro
+AU  - Padovani A
+FAU - Cotelli, Maria
+AU  - Cotelli M
+FAU - Miniussi, Carlo
+AU  - Miniussi C
+LA  - eng
+PT  - Journal Article
+PL  - United States
+TA  - Neuropsychology
+JT  - Neuropsychology
+JID - 8904467
+SB  - IM
+MH  - Aged
+MH  - Aged, 80 and over
+MH  - Analysis of Variance
+MH  - Case-Control Studies
+MH  - Discrimination, Psychological/*physiology
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Male
+MH  - Middle Aged
+MH  - Perceptual Disorders/*physiopathology
+MH  - Psychomotor Performance
+MH  - Reading
+MH  - Time Perception/*physiology
+EDAT- 2011/03/09 06:00
+MHDA- 2011/07/02 06:00
+CRDT- 2011/03/09 06:00
+PHST- 2011/03/09 06:00 [entrez]
+PHST- 2011/03/09 06:00 [pubmed]
+PHST- 2011/07/02 06:00 [medline]
+AID - 2011-04169-006 [pii]
+AID - 10.1037/a0021304 [doi]
+PST - ppublish
+SO  - Neuropsychology. 2011 Mar;25(2):193-200. doi: 10.1037/a0021304.
+
+PMID- 24521842
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20140401
+LR  - 20181113
+IS  - 1074-9357 (Print)
+IS  - 1074-9357 (Linking)
+VI  - 21
+IP  - 1
+DP  - 2014 Jan-Feb
+TI  - Assessment of neglect dyslexia with functional reading materials.
+PG  - 75-86
+LID - 10.1310/tsr2101-75 [doi]
+AB  - BACKGROUND: Spatial neglect is a neurocognitive disorder that affects perception, 
+      representation, and/or motor planning. Neglect dyslexia in spatial neglect after 
+      right hemisphere damage may co-occur with, or be dissociated from, other spatial 
+      neglect signs. Previous neglect dyslexia research focused on word-level stimuli and 
+      reading errors. Using single words for assessment may leave some people with neglect 
+      dyslexia undiagnosed, and assessment materials that are closer to texts read in real 
+      life may better capture neglect dyslexia. METHOD: The authors tested reading in 67 
+      right hemisphere stroke survivors with 4 types of text materials: words, phrases, an 
+      article, and a menu. RESULTS: Accuracy on reading the menu and article texts was 
+      significantly poorer than reading the words and phrases. The hypothesis that 
+      assessment materials with ecological validity such as reading a menu and reading an 
+      article may be more challenging than reading single words and phrases was supported. 
+      CONCLUSION: Results suggest that neglect dyslexia assessment after stroke should 
+      include text materials comparable to those read in everyday life. Increasing the 
+      spatial extent of training materials in future research might also yield better 
+      functional generalization after right brain stroke.
+FAU - Galletta, Elizabeth E
+AU  - Galletta EE
+AD  - Hunter College, The City University of New York, New York, New York The Graduate 
+      School and University Center, The City University of New York, New York, New York 
+      Kessler Foundation Research Center, West Orange, New Jersey.
+FAU - Campanelli, Luca
+AU  - Campanelli L
+AD  - The Graduate School and University Center, The City University of New York, New 
+      York, New York.
+FAU - Maul, Kristen K
+AU  - Maul KK
+AD  - Kessler Foundation Research Center, West Orange, New Jersey.
+FAU - Barrett, A M
+AU  - Barrett AM
+AD  - Kessler Foundation Research Center, West Orange, New Jersey New Jersey Medical 
+      School, Newark, New Jersey.
+LA  - eng
+GR  - K02 NS047099/NS/NINDS NIH HHS/United States
+GR  - K24 HD062647/HD/NICHD NIH HHS/United States
+GR  - R01 NS055808/NS/NINDS NIH HHS/United States
+GR  - K02 NS47099/NS/NINDS NIH HHS/United States
+PT  - Journal Article
+PT  - Research Support, N.I.H., Extramural
+PT  - Research Support, Non-U.S. Gov't
+PT  - Research Support, U.S. Gov't, Non-P.H.S.
+TA  - Top Stroke Rehabil
+JT  - Topics in stroke rehabilitation
+JID - 9439750
+SB  - IM
+MH  - Aged
+MH  - Aged, 80 and over
+MH  - Dyslexia/*complications/*etiology
+MH  - Female
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - Logistic Models
+MH  - Male
+MH  - Middle Aged
+MH  - Neuropsychological Tests
+MH  - Perceptual Disorders/*complications/*etiology
+MH  - Predictive Value of Tests
+MH  - Reading
+MH  - Stroke/*complications
+PMC - PMC3929236
+MID - NIHMS496505
+OTO - NOTNLM
+OT  - assessment
+OT  - neglect dyslexia
+OT  - right hemisphere damage
+OT  - spatial neglect
+EDAT- 2014/02/14 06:00
+MHDA- 2014/04/02 06:00
+CRDT- 2014/02/14 06:00
+PHST- 2014/02/14 06:00 [entrez]
+PHST- 2014/02/14 06:00 [pubmed]
+PHST- 2014/04/02 06:00 [medline]
+AID - M40056P32211T245 [pii]
+AID - 10.1310/tsr2101-75 [doi]
+PST - ppublish
+SO  - Top Stroke Rehabil. 2014 Jan-Feb;21(1):75-86. doi: 10.1310/tsr2101-75.
+
+PMID- 2265933
+OWN - NLM
+STAT- MEDLINE
+DCOM- 19910212
+LR  - 20190828
+IS  - 0020-7454 (Print)
+IS  - 0020-7454 (Linking)
+VI  - 53
+IP  - 2-4
+DP  - 1990 Aug
+TI  - Relation of spatial reasoning ability to hand performance in male and female 
+      left-handers to familial sinistrality and writing hand.
+PG  - 143-55
+AB  - The relation of mental ability for spatial reasoning to hand performance was studied 
+      in male and female left-handers considering familial sinistrality and writing hand. 
+      Hand performance was assessed by a dot-filling test; hand preference was assessed by 
+      the Edinburgh Handedness Inventory (Geschwind scores). Nonverbal intelligence 
+      (spatial reasoning) was measured by the Cattell's Culture Fair Intelligence Test. 
+      The relationship between IQ and hand performance was found to be more complicated 
+      than expected. This was associated with sex, familial sinistrality, and writing 
+      hand, which created different patterns in interactions between motor and cognitive 
+      systems. It was concluded that the brain benefits from different strategies by using 
+      both hemispheres in a competitive and complementary manner where necessary to 
+      achieve a high visual-spatial performance depending upon genetic preprograms.
+FAU - Tan, U
+AU  - Tan U
+AD  - Atatürk University, Medical Faculty, Erzurum, Turkey.
+LA  - eng
+PT  - Journal Article
+PL  - England
+TA  - Int J Neurosci
+JT  - The International journal of neuroscience
+JID - 0270707
+SB  - IM
+MH  - Adult
+MH  - Female
+MH  - *Functional Laterality
+MH  - Hand/*physiology
+MH  - *Handwriting
+MH  - Humans
+MH  - *Intelligence
+MH  - Male
+MH  - *Motor Skills
+MH  - Sex Characteristics
+MH  - *Space Perception
+EDAT- 1990/08/01 00:00
+MHDA- 1990/08/01 00:01
+CRDT- 1990/08/01 00:00
+PHST- 1990/08/01 00:00 [pubmed]
+PHST- 1990/08/01 00:01 [medline]
+PHST- 1990/08/01 00:00 [entrez]
+AID - 10.3109/00207459008986596 [doi]
+PST - ppublish
+SO  - Int J Neurosci. 1990 Aug;53(2-4):143-55. doi: 10.3109/00207459008986596.
+
+PMID- 280219
+OWN - NLM
+STAT- MEDLINE
+DCOM- 19781227
+LR  - 20190616
+IS  - 0077-8923 (Print)
+IS  - 0077-8923 (Linking)
+VI  - 299
+DP  - 1977 Sep 30
+TI  - An anthropological perspective on the evolution and lateralization of the brain.
+PG  - 424-47
+AB  - The purpose of this paper is to review the anthropological evidence relating to the 
+      cultural determinants of the right-hand first postaulted by Hertz in his classic 
+      study. Also a genetic/cultural conformity model of handedness is presented that 
+      postulates that the incidence of handedness in a society is held to result both from 
+      the genetic expression of handedness interacting with cultural pressures towards 
+      conformity. The evolutionary basis for the hemispheric functional organization into 
+      cognitive and perceptual hemispheric functions is discussed in terms of 
+      "right-handed dominant homozygotes, DD," "heterozygotes, DR," mixed-handers, and 
+      "left-handed recessive homozygotes, RR." The cross-cultural distribution of 
+      handedness provides support for this model since the more conforming 
+      agriculturalists as measured by the Asch Test have a significantly lower incidence 
+      of left-handedness (0.59%, 1.5% and 3.4%), while the more permissively socialized 
+      Eskimo and Arunta hunters, who are seen to be more independent on the Asch Test, 
+      have 11.3% and 10.5% left-handers, respectively. Also, due to the greater pressures 
+      for females to conform in agricultural societies, the incidence of female 
+      left-handedness in agricultural societies is 0% out of 330 female Ss, with 3.8%, 
+      0.79%, and 2.5% in agricultural males, as contrasted with the Eskimo hunters who 
+      have 12.5% left-handed males and 10.3% left-handed females, showing no significant 
+      sex difference. A further Hong Kong-English study also supports the genetic/cultural 
+      conformity model with a significantly lower incidence of Hong Kong Chinese 
+      left-handers (RR: male = 2.7%, and female = 4.2%). The next section, concerned with 
+      the neonatal sex-hormone differentiation and lateralization processes, provides a 
+      neuropsychologic theory relating to spatial and linguistic skills that is relevant 
+      to the following section, which deals with relationships between laterality and 
+      cognitive style. The results are also presented for the Alaskan Eskimo in relation 
+      to hand, eye, auditory dominance and cognitive style. The analysis of Eskimo 
+      fixed-versus mixed-laterality data also confirms, as predicted, that both within and 
+      across a modality (e.g., right hand/right eye/right ear) fixed right-dominance 
+      Eskimo Ss are more field-independent than mixed-dominance Ss, while the fixed 
+      left-dominance Ss are the most field-dependent and have lower spatial skills. The 
+      discussion section reviews the papers relating to the genetic/conformity model of 
+      handedness, as well as laterality and cognitive style. The evolutionary adaptive 
+      significance of sex differences in gonadal differentiation and lateralization of the 
+      brain on spatial and linguistic skills are also reviewed. The conclusions are 
+      concerned with the implications for biosocial theory and the rapidly changing 
+      incidence of left-handedness due to accompanying changes in cultural pressures both 
+      within and across cultures.
+FAU - Dawson, J L
+AU  - Dawson JL
+LA  - eng
+PT  - Journal Article
+PL  - United States
+TA  - Ann N Y Acad Sci
+JT  - Annals of the New York Academy of Sciences
+JID - 7506858
+RN  - 0 (Estrogens)
+RN  - 3XMK78S47O (Testosterone)
+SB  - IM
+MH  - Adult
+MH  - Animals
+MH  - *Anthropology, Cultural
+MH  - *Anthropology, Physical
+MH  - *Biological Evolution
+MH  - Brain/*physiology
+MH  - Cognition/physiology
+MH  - Cross-Cultural Comparison
+MH  - Dominance, Cerebral/*physiology
+MH  - Estrogens/blood
+MH  - Female
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - Infant, Newborn
+MH  - Male
+MH  - Perception/physiology
+MH  - Phenotype
+MH  - Rats
+MH  - Speech/physiology
+MH  - Testosterone/blood
+EDAT- 1977/09/30 00:00
+MHDA- 1977/09/30 00:01
+CRDT- 1977/09/30 00:00
+PHST- 1977/09/30 00:00 [pubmed]
+PHST- 1977/09/30 00:01 [medline]
+PHST- 1977/09/30 00:00 [entrez]
+AID - 10.1111/j.1749-6632.1977.tb41927.x [doi]
+PST - ppublish
+SO  - Ann N Y Acad Sci. 1977 Sep 30;299:424-47. doi: 10.1111/j.1749-6632.1977.tb41927.x.
+
+PMID- 28964939
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20180724
+LR  - 20180914
+IS  - 1973-8102 (Electronic)
+IS  - 0010-9452 (Linking)
+VI  - 96
+DP  - 2017 Nov
+TI  - Face perception in pure alexia: Complementary contributions of the left fusiform 
+      gyrus to facial identity and facial speech processing.
+PG  - 59-72
+LID - S0010-9452(17)30286-1 [pii]
+LID - 10.1016/j.cortex.2017.08.029 [doi]
+AB  - Recent concepts of cerebral visual processing predict from overlapping patterns of 
+      face and word activation in cortex that left fusiform lesions will not only cause 
+      pure alexia but also lead to mild impairments of face processing. Our goal was to 
+      determine if alexic subjects had deficits in facial identity processing similar to 
+      those seen after right fusiform lesions, or complementary deficits affecting 
+      different aspects of face processing. We studied four alexic patients whose lesions 
+      involved the left fusiform gyrus and one prosopagnosic subject with a right fusiform 
+      lesion, on standard tests of face perception and recognition. We evaluated their 
+      ability first to process faces in linear contour images, and second to detect, 
+      discriminate, identify and integrate facial speech patterns into perception. We 
+      found that all five patients were impaired in face matching across viewpoint, but 
+      the alexic subjects performed worse with line-drawn faces, while the prosopagnosic 
+      subject did not. Alexic subjects could detect facial speech patterns but had trouble 
+      identifying them and did not integrate facial speech patterns with speech sounds, 
+      whereas identification and integration was intact in the prosopagnosic subject. We 
+      conclude that, in addition to their role in reading, the left-sided regions damaged 
+      in alexic subjects participate in the perception of facial identity but in a 
+      non-redundant fashion, focusing on the information in linear contours at higher 
+      spatial frequencies. In addition they have a dominant role in processing facial 
+      speech patterns, another visual aspect of language processing.
+CI  - Copyright © 2017 Elsevier Ltd. All rights reserved.
+FAU - Albonico, Andrea
+AU  - Albonico A
+AD  - Human Vision and Eye Movement Laboratory, Departments of Medicine (Neurology), 
+      Ophthalmology and Visual Sciences, Psychology, University of British Columbia, 
+      Vancouver, Canada; NeuroMI - Milan Center for Neuroscience, Milano, Italy.
+FAU - Barton, Jason J S
+AU  - Barton JJS
+AD  - Human Vision and Eye Movement Laboratory, Departments of Medicine (Neurology), 
+      Ophthalmology and Visual Sciences, Psychology, University of British Columbia, 
+      Vancouver, Canada. Electronic address: jasonbarton@shaw.ca.
+LA  - eng
+GR  - MOP-106511/CIHR/Canada
+GR  - MOP-102567/CIHR/Canada
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20170904
+PL  - Italy
+TA  - Cortex
+JT  - Cortex; a journal devoted to the study of the nervous system and behavior
+JID - 0100725
+SB  - IM
+MH  - Adult
+MH  - Aged
+MH  - Alexia, Pure/*physiopathology
+MH  - Facial Recognition/physiology
+MH  - Female
+MH  - Form Perception/physiology
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Male
+MH  - Middle Aged
+MH  - Pattern Recognition, Visual/*physiology
+MH  - Photic Stimulation/methods
+MH  - *Speech
+OTO - NOTNLM
+OT  - *McGurk illusion
+OT  - *Object recognition
+OT  - *Prosopagnosia
+OT  - *Spatial frequency
+EDAT- 2017/10/02 06:00
+MHDA- 2018/07/25 06:00
+CRDT- 2017/10/02 06:00
+PHST- 2016/08/25 00:00 [received]
+PHST- 2017/05/16 00:00 [revised]
+PHST- 2017/08/24 00:00 [accepted]
+PHST- 2017/10/02 06:00 [pubmed]
+PHST- 2018/07/25 06:00 [medline]
+PHST- 2017/10/02 06:00 [entrez]
+AID - S0010-9452(17)30286-1 [pii]
+AID - 10.1016/j.cortex.2017.08.029 [doi]
+PST - ppublish
+SO  - Cortex. 2017 Nov;96:59-72. doi: 10.1016/j.cortex.2017.08.029. Epub 2017 Sep 4.
+
+PMID- 27450929
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20170828
+LR  - 20171204
+IS  - 1872-6240 (Electronic)
+IS  - 0006-8993 (Linking)
+VI  - 1648
+IP  - Pt A
+DP  - 2016 Oct 1
+TI  - The role of parieto-temporal connectivity in pure neglect dyslexia.
+PG  - 144-151
+LID - S0006-8993(16)30515-7 [pii]
+LID - 10.1016/j.brainres.2016.07.033 [doi]
+AB  - The initial stages of reading are characterised by parallel and effortless access to 
+      letters constituting a word. Neglect dyslexia is an acquired reading disorder 
+      characterised by omission or substitution of the initial or the final letters of 
+      words. Rarely, the disorder appears in a'pure' form that is, without other signs of 
+      spatial neglect. Neglect dyslexia is linked to damage involving the inferior 
+      parietal lobe and regions of the temporal lobe, but the precise anatomical basis of 
+      the pure form of the disorder is unknown. Here, we show that pure neglect dyslexia 
+      is associated with decreased structural connectivity between the inferior parietal 
+      and lateral temporal lobe. We examined patient DM, who following bilateral 
+      occipito-parietal damage presented left neglect dyslexia together with right visual 
+      field loss, but no signs of spatial neglect. DM's reading errors were affected by 
+      word length and were much more frequent for pseudowords than for existing words. 
+      Most errors were omissions or substitutions of the first or second letter, and the 
+      spatial distribution of errors was similar for stimuli presented left or right of 
+      fixation. The brain lesions of DM comprised the inferior and superior parietal 
+      lobule as well as the cuneus and precuneus of the left hemisphere, and the angular 
+      gyrus and lateral occipital cortex of the right hemisphere. Diffusion tensor imaging 
+      revealed bilateral decrease of fibre tracts connecting the inferior parietal lobule 
+      with the superior and middle temporal cortex. These findings suggest that 
+      parieto-temporal connections play a significant role for the deployment of attention 
+      within words during reading.
+CI  - Copyright © 2016 Elsevier B.V. All rights reserved.
+FAU - Ptak, Radek
+AU  - Ptak R
+AD  - Division of Neurorehabilitation, Department of Clinical Neurosciences, University 
+      Hospitals Geneva, Geneva, Switzerland; Laboratory of Cognitive Neurorehabilitation, 
+      Faculty of Medicine, University of Geneva, Switzerland; Faculty of Psychology and 
+      Educational Sciences, University of Geneva, Geneva, Switzerland. Electronic address: 
+      radek.ptak@hcuge.ch.
+FAU - Di Pietro, Marie
+AU  - Di Pietro M
+AD  - Division of Neurorehabilitation, Department of Clinical Neurosciences, University 
+      Hospitals Geneva, Geneva, Switzerland.
+FAU - Pignat, Jean-Michel
+AU  - Pignat JM
+AD  - Unit of Acute Neurorehabilitation, Department of Clinical Neurosciences, University 
+      Hospital Lausanne, 1011 Lausanne, Switzerland.
+LA  - eng
+PT  - Case Reports
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20160720
+PL  - Netherlands
+TA  - Brain Res
+JT  - Brain research
+JID - 0045503
+SB  - IM
+MH  - Diffusion Tensor Imaging
+MH  - Dyslexia/etiology/*physiopathology
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - Male
+MH  - Middle Aged
+MH  - Occipital Lobe/physiopathology
+MH  - Parietal Lobe/*physiopathology
+MH  - Perceptual Disorders/complications
+MH  - Reading
+MH  - Temporal Lobe/*physiopathology
+MH  - Visual Fields/physiology
+OTO - NOTNLM
+OT  - *Disconnection
+OT  - *Neglect dyslexia
+OT  - *Parietal lobe
+OT  - *Reading
+OT  - *Spatial neglect
+OT  - *Temporal lobe
+OT  - *Visual attention
+EDAT- 2016/07/28 06:00
+MHDA- 2017/08/29 06:00
+CRDT- 2016/07/25 06:00
+PHST- 2016/03/06 00:00 [received]
+PHST- 2016/07/01 00:00 [revised]
+PHST- 2016/07/19 00:00 [accepted]
+PHST- 2016/07/25 06:00 [entrez]
+PHST- 2016/07/28 06:00 [pubmed]
+PHST- 2017/08/29 06:00 [medline]
+AID - S0006-8993(16)30515-7 [pii]
+AID - 10.1016/j.brainres.2016.07.033 [doi]
+PST - ppublish
+SO  - Brain Res. 2016 Oct 1;1648(Pt A):144-151. doi: 10.1016/j.brainres.2016.07.033. Epub 
+      2016 Jul 20.
+
+PMID- 18420234
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20080826
+LR  - 20191210
+IS  - 0028-3932 (Print)
+IS  - 0028-3932 (Linking)
+VI  - 46
+IP  - 8
+DP  - 2008
+TI  - Hippocampal activation during episodic and semantic memory retrieval: comparing 
+      category production and category cued recall.
+PG  - 2109-21
+LID - 10.1016/j.neuropsychologia.2008.02.030 [doi]
+AB  - Whether or not the hippocampus participates in semantic memory retrieval has been 
+      the focus of much debate in the literature. However, few neuroimaging studies have 
+      directly compared hippocampal activation during semantic and episodic retrieval 
+      tasks that are well matched in all respects other than the source of the retrieved 
+      information. In Experiment 1, we compared hippocampal fMRI activation during a 
+      classic semantic memory task, category production, and an episodic version of the 
+      same task, category cued recall. Left hippocampal activation was observed in both 
+      episodic and semantic conditions, although other regions of the brain clearly 
+      distinguished the two tasks. Interestingly, participants reported using retrieval 
+      strategies during the semantic retrieval task that relied on autobiographical and 
+      spatial information; for example, visualizing themselves in their kitchen while 
+      producing items for the category kitchen utensils. In Experiment 2, we considered 
+      whether the use of these spatial and autobiographical retrieval strategies could 
+      have accounted for the hippocampal activation observed in Experiment 1. Categories 
+      were presented that elicited one of three retrieval strategy types, autobiographical 
+      and spatial, autobiographical and nonspatial, and neither autobiographical nor 
+      spatial. Once again, similar hippocampal activation was observed for all three 
+      category types, regardless of the inclusion of spatial or autobiographical content. 
+      We conclude that the distinction between semantic and episodic memory is more 
+      complex than classic memory models suggest.
+FAU - Ryan, Lee
+AU  - Ryan L
+AD  - Cognition & Neuroimaging Laboratories, Department of Psychology, University of 
+      Arizona, Tucson, AZ 85721-0068, USA. ryant@email.arizona.edu
+FAU - Cox, Christine
+AU  - Cox C
+FAU - Hayes, Scott M
+AU  - Hayes SM
+FAU - Nadel, Lynn
+AU  - Nadel L
+LA  - eng
+GR  - R01 NS044107-05/NS/NINDS NIH HHS/United States
+GR  - R01 NS044107-01A1/NS/NINDS NIH HHS/United States
+GR  - R01 NS044107-03/NS/NINDS NIH HHS/United States
+GR  - R01 NS044107-04/NS/NINDS NIH HHS/United States
+GR  - R01 NS044107-03S1/NS/NINDS NIH HHS/United States
+GR  - R01 NS044107/NS/NINDS NIH HHS/United States
+GR  - R01 NS044107-02/NS/NINDS NIH HHS/United States
+PT  - Journal Article
+DEP - 20080318
+TA  - Neuropsychologia
+JT  - Neuropsychologia
+JID - 0020713
+RN  - S88TT14065 (Oxygen)
+SB  - IM
+MH  - Adolescent
+MH  - Adult
+MH  - *Brain Mapping
+MH  - *Cues
+MH  - Female
+MH  - Functional Laterality
+MH  - Hippocampus/blood supply/*physiology
+MH  - Humans
+MH  - Image Processing, Computer-Assisted
+MH  - Male
+MH  - Mental Recall/*physiology
+MH  - Oxygen/blood
+MH  - Retention, Psychology/*physiology
+MH  - *Semantics
+PMC - PMC2482601
+MID - NIHMS56375
+EDAT- 2008/04/19 09:00
+MHDA- 2008/08/30 09:00
+CRDT- 2008/04/19 09:00
+PHST- 2007/10/03 00:00 [received]
+PHST- 2008/02/25 00:00 [revised]
+PHST- 2008/02/25 00:00 [accepted]
+PHST- 2008/04/19 09:00 [pubmed]
+PHST- 2008/08/30 09:00 [medline]
+PHST- 2008/04/19 09:00 [entrez]
+AID - S0028-3932(08)00092-4 [pii]
+AID - 10.1016/j.neuropsychologia.2008.02.030 [doi]
+PST - ppublish
+SO  - Neuropsychologia. 2008;46(8):2109-21. doi: 10.1016/j.neuropsychologia.2008.02.030. 
+      Epub 2008 Mar 18.
+
+PMID- 26666706
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20161013
+LR  - 20181113
+IS  - 2045-2322 (Electronic)
+IS  - 2045-2322 (Linking)
+VI  - 5
+DP  - 2015 Dec 15
+TI  - Effect of handedness on brain activity patterns and effective connectivity network 
+      during the semantic task of Chinese characters.
+PG  - 18262
+LID - 10.1038/srep18262 [doi]
+LID - 18262
+AB  - Increasing efforts have been denoted to elucidating the effective connectivity (EC) 
+      among brain regions recruited by certain language task; however, it remains unclear 
+      the impact of handedness on the EC network underlying language processing. In 
+      particularly, this has not been investigated in Chinese language, which shows 
+      several differences from alphabetic language. This study thereby explored the 
+      functional activity patterns and the EC network during a Chinese semantic task based 
+      on functional MRI data of healthy left handers (LH) and right handers (RH). We found 
+      that RH presented a left lateralized activity pattern in cerebral cortex and a right 
+      lateralized pattern in cerebellum; while LH were less lateralized than RH in both 
+      cerebral and cerebellar areas. The conditional Granger causality method in 
+      deconvolved BOLD level further demonstrated more interhemispheric directional 
+      connections in LH than RH group, suggesting better bihemispheric coordination and 
+      increased interhemispheric communication in LH. Furthermore, we found significantly 
+      increased EC from right middle occipital gyrus to bilateral insula (INS) while 
+      decreased EC from left INS to left precentral gyrus in LH group comparing to RH 
+      group, implying that handedness may differentiate the causal relationship of 
+      information processing in integration of visual-spatial analysis and semantic word 
+      retrieval of Chinese characters.
+FAU - Gao, Qing
+AU  - Gao Q
+AD  - School of Mathematical Sciences, University of Electronic Science and Technology of 
+      China, Chengdu, 611731, China.
+FAU - Wang, Junping
+AU  - Wang J
+AD  - Department of Radiology, Tianjin Medical University General Hospital, Tianjin, 
+      300052, China.
+FAU - Yu, Chunshui
+AU  - Yu C
+AD  - Department of Radiology, Tianjin Medical University General Hospital, Tianjin, 
+      300052, China.
+FAU - Chen, Huafu
+AU  - Chen H
+AD  - Key laboratory for Neuroinformation of Ministry of Education, School of Life Science 
+      and Technology, University of Electronic Science and Technology of China, Chengdu, 
+      610054, China.
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20151215
+TA  - Sci Rep
+JT  - Scientific reports
+JID - 101563288
+SB  - IM
+MH  - Asian Continental Ancestry Group
+MH  - Brain/*physiology
+MH  - Brain Mapping
+MH  - China
+MH  - *Connectome
+MH  - *Functional Laterality
+MH  - Humans
+MH  - Magnetic Resonance Imaging
+MH  - *Semantics
+PMC - PMC4678893
+EDAT- 2015/12/17 06:00
+MHDA- 2016/10/14 06:00
+CRDT- 2015/12/16 06:00
+PHST- 2015/06/29 00:00 [received]
+PHST- 2015/11/13 00:00 [accepted]
+PHST- 2015/12/16 06:00 [entrez]
+PHST- 2015/12/17 06:00 [pubmed]
+PHST- 2016/10/14 06:00 [medline]
+AID - srep18262 [pii]
+AID - 10.1038/srep18262 [doi]
+PST - epublish
+SO  - Sci Rep. 2015 Dec 15;5:18262. doi: 10.1038/srep18262.
+
+PMID- 2265931
+OWN - NLM
+STAT- MEDLINE
+DCOM- 19910212
+LR  - 20190828
+IS  - 0020-7454 (Print)
+IS  - 0020-7454 (Linking)
+VI  - 53
+IP  - 2-4
+DP  - 1990 Aug
+TI  - Relation of hand skill to spatial reasoning in male and female left-handers with 
+      left- and right-hand writing.
+PG  - 121-33
+AB  - The relation of mental ability for spatial reasoning (Cattell's Culture Fair 
+      Intelligence Test) to hand skill assessed by peg-moving task was studied in normal 
+      left-handers. Nonlinear, quadratic relationships were established between these two 
+      parameters exhibiting different characteristics according to sex and writing hand. 
+      It was concluded that the contributions of the right and left cerebral hemispheres 
+      to the cognitive-motor output of the brain depend on sex and writing hand as well as 
+      the degree of left-handedness in left-handers.
+FAU - Tan, U
+AU  - Tan U
+AD  - Atatürk University, Medical Faculty, Erzurum, Turkey.
+LA  - eng
+PT  - Journal Article
+PL  - England
+TA  - Int J Neurosci
+JT  - The International journal of neuroscience
+JID - 0270707
+SB  - IM
+MH  - Adolescent
+MH  - Adult
+MH  - Child
+MH  - Female
+MH  - *Functional Laterality
+MH  - Hand/*physiology
+MH  - *Handwriting
+MH  - Humans
+MH  - *Intelligence
+MH  - Male
+MH  - *Motor Skills
+MH  - Neuropsychological Tests
+MH  - Sex Characteristics
+MH  - *Space Perception
+MH  - Time Factors
+EDAT- 1990/08/01 00:00
+MHDA- 1990/08/01 00:01
+CRDT- 1990/08/01 00:00
+PHST- 1990/08/01 00:00 [pubmed]
+PHST- 1990/08/01 00:01 [medline]
+PHST- 1990/08/01 00:00 [entrez]
+AID - 10.3109/00207459008986594 [doi]
+PST - ppublish
+SO  - Int J Neurosci. 1990 Aug;53(2-4):121-33. doi: 10.3109/00207459008986594.
+
+PMID- 23344530
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20140204
+LR  - 20181113
+IS  - 1612-4790 (Electronic)
+IS  - 1612-4782 (Linking)
+VI  - 14
+IP  - 3
+DP  - 2013 Aug
+TI  - Priming the mental time-line: effects of modality and processing mode.
+PG  - 231-44
+LID - 10.1007/s10339-013-0537-5 [doi]
+AB  - The notion of a mental time-line (i.e., past corresponds to left and future 
+      corresponds to right) supports the conceptual metaphor view assuming that abstract 
+      concepts like "time" are grounded in cognitively more accessible concepts like 
+      "space." In five experiments, we further investigated the relationship between 
+      temporal and spatial representations and examined whether or not the spatial 
+      correspondents of time are unintentionally activated. We employed a priming 
+      paradigm, in which visual or auditory prime words (i.e., temporal adverbs such as 
+      yesterday, tomorrow) preceded a colored square. In all experiments, participants 
+      discriminated the color of this square by responding with the left or the right 
+      hand. Although the temporal reference of the priming adverb was task irrelevant in 
+      Experiment 1, visually presented primes facilitated responses to the square in 
+      correspondence with the direction of the mental time-line. This priming effect was 
+      absent in Experiments 2, 3, and 5, in which the primes were presented auditorily and 
+      the temporal reference of the words could be ignored. The effect, however, emerged 
+      when attention was oriented to the temporal content of the auditory prime words in 
+      Experiment 4. The results suggest that task demands differentially modulate the 
+      activation of the mental time-line within the visual and auditory modality and 
+      support a flexible association between conceptual codes.
+FAU - Rolke, Bettina
+AU  - Rolke B
+AD  - Evolutionary Cognition, Department of Psychology, University of Tübingen, 
+      Schleichstrasse 4, 72076, Tübingen, Germany. bettina.rolke@uni-tuebingen.de
+FAU - Fernández, Susana Ruiz
+AU  - Fernández SR
+FAU - Schmid, Mareike
+AU  - Schmid M
+FAU - Walker, Matthias
+AU  - Walker M
+FAU - Lachmair, Martin
+AU  - Lachmair M
+FAU - López, Juan José Rahona
+AU  - López JJ
+FAU - Hervás, Gonzalo
+AU  - Hervás G
+FAU - Vázquez, Carmelo
+AU  - Vázquez C
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20130124
+PL  - Germany
+TA  - Cogn Process
+JT  - Cognitive processing
+JID - 101177984
+SB  - IM
+MH  - Acoustic Stimulation
+MH  - Attention/physiology
+MH  - Cognition/physiology
+MH  - *Cues
+MH  - Female
+MH  - Fixation, Ocular
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - Male
+MH  - Photic Stimulation
+MH  - Psychomotor Performance/physiology
+MH  - Reaction Time/physiology
+MH  - Reading
+MH  - Space Perception/physiology
+MH  - Time Perception/*physiology
+MH  - Young Adult
+EDAT- 2013/01/25 06:00
+MHDA- 2014/02/05 06:00
+CRDT- 2013/01/25 06:00
+PHST- 2012/09/21 00:00 [received]
+PHST- 2013/01/04 00:00 [accepted]
+PHST- 2013/01/25 06:00 [entrez]
+PHST- 2013/01/25 06:00 [pubmed]
+PHST- 2014/02/05 06:00 [medline]
+AID - 10.1007/s10339-013-0537-5 [doi]
+PST - ppublish
+SO  - Cogn Process. 2013 Aug;14(3):231-44. doi: 10.1007/s10339-013-0537-5. Epub 2013 Jan 
+      24.
+
+PMID- 22470500
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20120803
+LR  - 20181113
+IS  - 1932-6203 (Electronic)
+IS  - 1932-6203 (Linking)
+VI  - 7
+IP  - 3
+DP  - 2012
+TI  - Human infants and baboons show the same pattern of handedness for a communicative 
+      gesture.
+PG  - e33959
+LID - 10.1371/journal.pone.0033959 [doi]
+LID - e33959
+AB  - To test the role of gestures in the origin of language, we studied hand preferences 
+      for grasping or pointing to objects at several spatial positions in human infants 
+      and adult baboons. If the roots of language are indeed in gestural communication, we 
+      expect that human infants and baboons will present a comparable difference in their 
+      pattern of laterality according to task: both should be more 
+      right-hand/left-hemisphere specialized when communicating by pointing than when 
+      simply grasping objects. Our study is the first to test both human infants and 
+      baboons on the same communicative task. Our results show remarkable convergence in 
+      the distribution of the two species' hand biases on the two kinds of tasks: In both 
+      human infants and baboons, right-hand preference was significantly stronger for the 
+      communicative task than for grasping objects. Our findings support the hypothesis 
+      that left-lateralized language may be derived from a gestural communication system 
+      that was present in the common ancestor of baboons and humans.
+FAU - Meunier, Helene
+AU  - Meunier H
+AD  - Primatology Centre of Strasbourg University, Fort Foch, Niederhausbergen, France. 
+      meunier.h@gmail.com
+FAU - Vauclair, Jacques
+AU  - Vauclair J
+FAU - Fagard, Jacqueline
+AU  - Fagard J
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20120321
+TA  - PLoS One
+JT  - PloS one
+JID - 101285081
+SB  - IM
+MH  - Animal Communication
+MH  - Animals
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - *Gestures
+MH  - Humans
+MH  - Infant
+MH  - Male
+MH  - Papio
+PMC - PMC3309962
+COIS- Competing Interests: The authors have declared that no competing interests exist.
+EDAT- 2012/04/04 06:00
+MHDA- 2012/08/04 06:00
+CRDT- 2012/04/04 06:00
+PHST- 2011/09/01 00:00 [received]
+PHST- 2012/02/20 00:00 [accepted]
+PHST- 2012/04/04 06:00 [entrez]
+PHST- 2012/04/04 06:00 [pubmed]
+PHST- 2012/08/04 06:00 [medline]
+AID - PONE-D-11-19248 [pii]
+AID - 10.1371/journal.pone.0033959 [doi]
+PST - ppublish
+SO  - PLoS One. 2012;7(3):e33959. doi: 10.1371/journal.pone.0033959. Epub 2012 Mar 21.

--- a/test/data/language-LF.nbib
+++ b/test/data/language-LF.nbib
@@ -1,0 +1,3219 @@
+PMID- 20691275
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20110119
+LR  - 20101022
+IS  - 1095-9572 (Electronic)
+IS  - 1053-8119 (Linking)
+VI  - 54
+IP  - 1
+DP  - 2011 Jan 1
+TI  - Domain-general mechanisms of complex working memory span.
+PG  - 550-9
+LID - 10.1016/j.neuroimage.2010.07.067 [doi]
+AB  - A new fMRI complex working memory span paradigm was used to identify brain regions 
+      making domain-general contributions to working memory task performance. For both 
+      verbal and spatial versions of the task, complex working memory span performance 
+      increased the activity in lateral prefrontal, anterior cingulate, and parietal 
+      cortices during the Encoding, Maintenance, and Coordination phase of task 
+      performance. Meanwhile, overlapping activity in anterior prefrontal and medial 
+      temporal lobe regions was associated with both verbal and spatial recall from 
+      working memory. These findings help to adjudicate several contested issues regarding 
+      the executive mechanisms of working memory, the separability of short-term and 
+      working memory in the verbal and spatial domains, and the relative contribution of 
+      short-term and long-term memory mechanisms to working memory capacity. The study 
+      also provides a vital bridge between psychometric and neuroimaging approaches to 
+      working memory, and constrains our understanding of how working memory may 
+      contribute to the broader landscape of cognitive performance.
+CI  - Copyright © 2010 Elsevier Inc. All rights reserved.
+FAU - Chein, Jason M
+AU  - Chein JM
+AD  - Temple University, Department of Psychology, Philadelphia PA 19122, USA. 
+      jchein@temple.edu
+FAU - Moore, Adam B
+AU  - Moore AB
+FAU - Conway, Andrew R A
+AU  - Conway AR
+LA  - eng
+PT  - Journal Article
+DEP - 20100804
+PL  - United States
+TA  - Neuroimage
+JT  - NeuroImage
+JID - 9215515
+SB  - IM
+MH  - Brain/*physiology
+MH  - Brain Mapping/methods
+MH  - Cerebellum/physiology
+MH  - Cognition
+MH  - Frontal Lobe/physiology
+MH  - Functional Laterality
+MH  - Humans
+MH  - Magnetic Resonance Imaging/*methods
+MH  - Memory, Short-Term/*physiology
+MH  - Mesencephalon/physiology
+MH  - Neurons/physiology
+MH  - Speech
+MH  - Task Performance and Analysis
+MH  - Thalamus/physiology
+MH  - Young Adult
+EDAT- 2010/08/10 06:00
+MHDA- 2011/01/20 06:00
+CRDT- 2010/08/10 06:00
+PHST- 2009/09/09 00:00 [received]
+PHST- 2010/06/03 00:00 [revised]
+PHST- 2010/07/22 00:00 [accepted]
+PHST- 2010/08/10 06:00 [entrez]
+PHST- 2010/08/10 06:00 [pubmed]
+PHST- 2011/01/20 06:00 [medline]
+AID - S1053-8119(10)01059-1 [pii]
+AID - 10.1016/j.neuroimage.2010.07.067 [doi]
+PST - ppublish
+SO  - Neuroimage. 2011 Jan 1;54(1):550-9. doi: 10.1016/j.neuroimage.2010.07.067. Epub 2010 
+      Aug 4.
+
+PMID- 28821674
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20171010
+LR  - 20190629
+IS  - 1529-2401 (Electronic)
+IS  - 0270-6474 (Print)
+IS  - 0270-6474 (Linking)
+VI  - 37
+IP  - 39
+DP  - 2017 Sep 27
+TI  - How Auditory Experience Differentially Influences the Function of Left and Right 
+      Superior Temporal Cortices.
+PG  - 9564-9573
+LID - 10.1523/JNEUROSCI.0846-17.2017 [doi]
+AB  - To investigate how hearing status, sign language experience, and task demands 
+      influence functional responses in the human superior temporal cortices (STC) we 
+      collected fMRI data from deaf and hearing participants (male and female), who either 
+      acquired sign language early or late in life. Our stimuli in all tasks were pictures 
+      of objects. We varied the linguistic and visuospatial processing demands in three 
+      different tasks that involved decisions about (1) the sublexical (phonological) 
+      structure of the British Sign Language (BSL) signs for the objects, (2) the semantic 
+      category of the objects, and (3) the physical features of the objects.Neuroimaging 
+      data revealed that in participants who were deaf from birth, STC showed increased 
+      activation during visual processing tasks. Importantly, this differed across 
+      hemispheres. Right STC was consistently activated regardless of the task whereas 
+      left STC was sensitive to task demands. Significant activation was detected in the 
+      left STC only for the BSL phonological task. This task, we argue, placed greater 
+      demands on visuospatial processing than the other two tasks. In hearing signers, 
+      enhanced activation was absent in both left and right STC during all three tasks. 
+      Lateralization analyses demonstrated that the effect of deafness was more 
+      task-dependent in the left than the right STC whereas it was more task-independent 
+      in the right than the left STC. These findings indicate how the absence of auditory 
+      input from birth leads to dissociable and altered functions of left and right STC in 
+      deaf participants.SIGNIFICANCE STATEMENT Those born deaf can offer unique insights 
+      into neuroplasticity, in particular in regions of superior temporal cortex (STC) 
+      that primarily respond to auditory input in hearing people. Here we demonstrate that 
+      in those deaf from birth the left and the right STC have altered and dissociable 
+      functions. The right STC was activated regardless of demands on visual processing. 
+      In contrast, the left STC was sensitive to the demands of visuospatial processing. 
+      Furthermore, hearing signers, with the same sign language experience as the deaf 
+      participants, did not activate the STCs. Our data advance current understanding of 
+      neural plasticity by determining the differential effects that hearing status and 
+      task demands can have on left and right STC function.
+CI  - Copyright © 2017 Twomey et al.
+FAU - Twomey, Tae
+AU  - Twomey T
+AUID- ORCID: 0000-0001-9749-5895
+AD  - ESRC Deafness, Cognition and Language Research Centre, University College London, 
+      WC1H 0PD, United Kingdom.
+AD  - Institute of Cognitive Neuroscience, University College London, WC1N 3AR, United 
+      Kingdom.
+FAU - Waters, Dafydd
+AU  - Waters D
+AD  - ESRC Deafness, Cognition and Language Research Centre, University College London, 
+      WC1H 0PD, United Kingdom.
+FAU - Price, Cathy J
+AU  - Price CJ
+AUID- ORCID: 0000-0001-7448-4835
+AD  - Wellcome Trust Centre for Neuroimaging, Institute of Neurology, University College 
+      London, WC1N 3BG, United Kingdom, and.
+FAU - Evans, Samuel
+AU  - Evans S
+AUID- ORCID: 0000-0001-9667-0671
+AD  - Institute of Cognitive Neuroscience, University College London, WC1N 3AR, United 
+      Kingdom.
+AD  - Psychology Department, University of Westminster, 115 New Cavendish Street, London, 
+      W1W 6UW.
+FAU - MacSweeney, Mairéad
+AU  - MacSweeney M
+AUID- ORCID: 0000-0002-2315-3507
+AD  - ESRC Deafness, Cognition and Language Research Centre, University College London, 
+      WC1H 0PD, United Kingdom, m.macsweeney@ucl.ac.uk.
+AD  - Institute of Cognitive Neuroscience, University College London, WC1N 3AR, United 
+      Kingdom.
+LA  - eng
+GR  - Wellcome Trust/United Kingdom
+GR  - MR/M023672/1/Medical Research Council/United Kingdom
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20170818
+TA  - J Neurosci
+JT  - The Journal of neuroscience : the official journal of the Society for Neuroscience
+JID - 8102140
+SB  - IM
+MH  - Adult
+MH  - *Auditory Perception
+MH  - Brain Mapping
+MH  - Case-Control Studies
+MH  - Deafness/*physiopathology
+MH  - Female
+MH  - *Functional Laterality
+MH  - Humans
+MH  - Magnetic Resonance Imaging
+MH  - Male
+MH  - *Memory, Short-Term
+MH  - Middle Aged
+MH  - Semantics
+MH  - *Sign Language
+MH  - Temporal Lobe/*physiology/physiopathology
+MH  - Visual Perception
+PMC - PMC5618270
+OTO - NOTNLM
+OT  - *deaf
+OT  - *language
+OT  - *plasticity
+OT  - *sign language
+OT  - *superior temporal cortex
+OT  - *visuo-spatial working memory
+EDAT- 2017/08/20 06:00
+MHDA- 2017/10/11 06:00
+CRDT- 2017/08/20 06:00
+PHST- 2017/03/28 00:00 [received]
+PHST- 2017/07/25 00:00 [revised]
+PHST- 2017/07/27 00:00 [accepted]
+PHST- 2017/08/20 06:00 [pubmed]
+PHST- 2017/10/11 06:00 [medline]
+PHST- 2017/08/20 06:00 [entrez]
+AID - JNEUROSCI.0846-17.2017 [pii]
+AID - 0846-17 [pii]
+AID - 10.1523/JNEUROSCI.0846-17.2017 [doi]
+PST - ppublish
+SO  - J Neurosci. 2017 Sep 27;37(39):9564-9573. doi: 10.1523/JNEUROSCI.0846-17.2017. Epub 
+      2017 Aug 18.
+
+PMID- 21056593
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20110418
+LR  - 20101227
+IS  - 1872-7549 (Electronic)
+IS  - 0166-4328 (Linking)
+VI  - 217
+IP  - 2
+DP  - 2011 Mar 1
+TI  - Functional cerebral lateralization and dual-task efficiency-testing the function of 
+      human brain lateralization using fTCD.
+PG  - 293-301
+LID - 10.1016/j.bbr.2010.10.029 [doi]
+AB  - It has been hypothesized that functional cerebral lateralization enhances cognitive 
+      performance. Evidence was found in birds and fish. Our study aimed to test this 
+      hypothesis by analyzing the relationship between cerebral lateralization and both 
+      single-task performance and dual-task efficiency in humans. We combined a dynamic 
+      Landmark task which is assumed to be primarily processed in the right hemisphere and 
+      a frequently used word generation task which is assumed to be primarily processed in 
+      the left hemisphere. For each task individual strength and direction of hemispheric 
+      lateralization was assessed using functional transcranial Doppler sonography (fTCD). 
+      For each subject (15 women, 11 men), performance was measured in the two 
+      single-tasks and in the dual-task condition. Performance was not related to strength 
+      or direction of lateralization in single-tasks. With regard to dual-task efficiency, 
+      we found the expected advantage of having a typical lateralization pattern. 
+      Moreover, the results showed a slight negative, rather than a positive, relationship 
+      between strength of lateralization and dual-task efficiency. Further analysis showed 
+      that this negative relationship may only be present in subjects showing 
+      non-significant lateralization for one or both tasks. Therefore, the hypothesis that 
+      cerebral lateralization enhances human cognitive performance is too general: having 
+      two functions significantly lateralized to different hemispheres enhances dual-task 
+      efficiency, in this group strength of lateralized does not matter. However, if one 
+      or both functions are not significantly lateralized overall performance is worse and 
+      in this group, performance is negatively related to increased strength of 
+      lateralization.
+CI  - Copyright Â© 2010 Elsevier B.V. All rights reserved.
+FAU - Lust, J M
+AU  - Lust JM
+AD  - Department of Clinical and Developmental NeuroPsychology, University of Groningen, 
+      Grote Kruisstraat 2/1, 9712 TS Groningen, The Netherlands.
+FAU - Geuze, R H
+AU  - Geuze RH
+FAU - Groothuis, A G G
+AU  - Groothuis AG
+FAU - Bouma, A
+AU  - Bouma A
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20101105
+PL  - Netherlands
+TA  - Behav Brain Res
+JT  - Behavioural brain research
+JID - 8004872
+SB  - IM
+MH  - Brain/*blood supply/*physiology
+MH  - *Brain Mapping
+MH  - Cerebrovascular Circulation/*physiology
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Language
+MH  - Male
+MH  - Neuropsychological Tests
+MH  - Spatial Behavior/physiology
+MH  - Statistics as Topic
+MH  - Ultrasonography, Doppler
+MH  - *Ultrasonography, Doppler, Transcranial
+MH  - Vocabulary
+MH  - Young Adult
+EDAT- 2010/11/09 06:00
+MHDA- 2011/04/19 06:00
+CRDT- 2010/11/09 06:00
+PHST- 2010/06/15 00:00 [received]
+PHST- 2010/10/18 00:00 [revised]
+PHST- 2010/10/22 00:00 [accepted]
+PHST- 2010/11/09 06:00 [entrez]
+PHST- 2010/11/09 06:00 [pubmed]
+PHST- 2011/04/19 06:00 [medline]
+AID - S0166-4328(10)00714-X [pii]
+AID - 10.1016/j.bbr.2010.10.029 [doi]
+PST - ppublish
+SO  - Behav Brain Res. 2011 Mar 1;217(2):293-301. doi: 10.1016/j.bbr.2010.10.029. Epub 
+      2010 Nov 5.
+
+PMID- 19439393
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20091019
+LR  - 20191210
+IS  - 1618-3169 (Print)
+IS  - 1618-3169 (Linking)
+VI  - 56
+IP  - 4
+DP  - 2009
+TI  - The Simon effect with conventional signals: a time-course analysis.
+PG  - 219-27
+LID - 10.1027/1618-3169.56.4.219 [doi]
+AB  - The Simon effect consists of a faster and a more accurate performance when spatial 
+      responses correspond to irrelevant-spatial stimuli than when they do not. The time 
+      course of the Simon effect was investigated using centrally presented conventional 
+      signals (arrows and spatial words) conveying spatial information through 
+      iconic-symbolic (Experiments 1 and 2) and semantic (Experiment 3) codes. 
+      Time-demanding object-inherent and semantic spatial codes were generated for arrows 
+      and words, respectively. This resulted in Simon effects increasing in size across 
+      increasing response times (RTs). However, different onsets of the Simon effect were 
+      displayed across RT distributions. For arrows, the Simon effect was already 
+      significant at the fastest RT intervals, providing clear evidence that they are 
+      distinctively more effective directional indicators compared to words.
+FAU - Pellicano, Antonello
+AU  - Pellicano A
+AD  - University of Bologna, Bologna, Italy. antonio.pellicano@unibo.it
+FAU - Lugli, Luisa
+AU  - Lugli L
+FAU - Baroni, Giulia
+AU  - Baroni G
+FAU - Nicoletti, Roberto
+AU  - Nicoletti R
+LA  - eng
+PT  - Journal Article
+PL  - Germany
+TA  - Exp Psychol
+JT  - Experimental psychology
+JID - 101138477
+SB  - IM
+MH  - *Attention
+MH  - *Conflict, Psychological
+MH  - *Functional Laterality
+MH  - Humans
+MH  - *Orientation
+MH  - *Pattern Recognition, Visual
+MH  - *Psychomotor Performance
+MH  - *Reaction Time
+MH  - Semantics
+EDAT- 2009/05/15 09:00
+MHDA- 2009/10/20 06:00
+CRDT- 2009/05/15 09:00
+PHST- 2009/05/15 09:00 [entrez]
+PHST- 2009/05/15 09:00 [pubmed]
+PHST- 2009/10/20 06:00 [medline]
+AID - 547T748243783H83 [pii]
+AID - 10.1027/1618-3169.56.4.219 [doi]
+PST - ppublish
+SO  - Exp Psychol. 2009;56(4):219-27. doi: 10.1027/1618-3169.56.4.219.
+
+PMID- 12684205
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20030828
+LR  - 20191025
+IS  - 0010-0277 (Print)
+IS  - 0010-0277 (Linking)
+VI  - 87
+IP  - 3
+DP  - 2003 Apr
+TI  - The mental representation of ordinal sequences is spatially organized.
+PG  - B87-95
+AB  - In the domain of numbers the existence of spatial components in the representation 
+      of numerical magnitude has been convincingly demonstrated by an association between 
+      number magnitude and response preference with faster left- than right-hand responses 
+      for small numbers and faster right- than left-hand responses for large numbers 
+      (Dehaene, S., Bossini, S., & Giraux, P. (1993) The mental representation of parity 
+      and number magnitude. Journal of Experimental Psychology: General, 122, 371-396). 
+      Because numbers convey not only real or integer meaning but also ordinal meaning, 
+      the question of whether non-numerical ordinal information is spatially coded 
+      naturally follows. While previous research failed to show an association between 
+      ordinal position and spatial response preference, we present two experiments 
+      involving months (Experiment 1) and letters (Experiment 2) in which spatial coding 
+      is demonstrated. Furthermore, the response-side effect was obtained with two 
+      different stimulus-response mappings. The association occurred both when ordinal 
+      information was relevant and when it was irrelevant to the task, showing that the 
+      spatial component of the ordinal representation can be automatically activated.
+FAU - Gevers, Wim
+AU  - Gevers W
+AD  - Department of Experimental Psychology, Ghent University, H. Dunantlaan 2, B-9000 
+      Ghent, Belgium. wim.gevers@rug.ac.be
+FAU - Reynvoet, Bert
+AU  - Reynvoet B
+FAU - Fias, Wim
+AU  - Fias W
+LA  - eng
+PT  - Comparative Study
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+PL  - Netherlands
+TA  - Cognition
+JT  - Cognition
+JID - 0367541
+SB  - IM
+MH  - Adult
+MH  - *Cognition
+MH  - *Concept Formation
+MH  - Functional Laterality
+MH  - Humans
+MH  - Language
+MH  - Mathematics
+MH  - *Problem Solving
+MH  - Reaction Time
+MH  - Task Performance and Analysis
+EDAT- 2003/04/10 05:00
+MHDA- 2003/08/29 05:00
+CRDT- 2003/04/10 05:00
+PHST- 2003/04/10 05:00 [pubmed]
+PHST- 2003/08/29 05:00 [medline]
+PHST- 2003/04/10 05:00 [entrez]
+AID - S0010027702002342 [pii]
+AID - 10.1016/s0010-0277(02)00234-2 [doi]
+PST - ppublish
+SO  - Cognition. 2003 Apr;87(3):B87-95. doi: 10.1016/s0010-0277(02)00234-2.
+
+PMID- 11194413
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20010215
+LR  - 20191025
+IS  - 0001-6918 (Print)
+IS  - 0001-6918 (Linking)
+VI  - 105
+IP  - 2-3
+DP  - 2000 Dec
+TI  - Lateralization of cognitive processes in the brain.
+PG  - 211-35
+AB  - The lateralization of cognitive processes in the brain is discussed. The traditional 
+      view of a language-visuo/spatial dichotomy of function between the hemispheres has 
+      been replaced by more subtle distinctions. The use of magnetic resonance imaging 
+      (MRI) to study brain morphology has resulted in a renewed focus on the relationship 
+      between structural and functional asymmetry. Focus has been on the role played by 
+      the planum temporale area in the posterior part of the superior temporal gyrus for 
+      language asymmetry, and the possible significance of the larger left planum. The 
+      dichotic listening technique is used to illustrate the difference between bottom-up, 
+      or stimulus-driven laterality versus top-down, or instruction-driven laterality. It 
+      is suggested that the hemispheric dominance observed at any time is the sum result 
+      of the dynamic interaction between bottom-up and top-down processing tendencies. 
+      Stimulus-driven laterality dominance is always monitored and modulated through 
+      top-down cognitive processes, like shifting of attention and changes in arousal. A 
+      model of top-down modulation of bottom-up laterality is presented with special 
+      reference to the understanding of psychiatric disorders.
+FAU - Hugdahl, K
+AU  - Hugdahl K
+AD  - Department of Biological and Medical Psychology, University of Bergen, Arstadveien 
+      21, 5009 Bergen, Norway. hugdahl@psych.uib.no
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+PT  - Review
+PL  - Netherlands
+TA  - Acta Psychol (Amst)
+JT  - Acta psychologica
+JID - 0370366
+SB  - IM
+MH  - Adult
+MH  - Aged
+MH  - Arachnoid Cysts/physiopathology
+MH  - Auditory Pathways
+MH  - Cognition/*physiology
+MH  - Female
+MH  - *Functional Laterality
+MH  - Humans
+MH  - Male
+MH  - Middle Aged
+MH  - *Neurolinguistic Programming
+MH  - Schizophrenia/physiopathology
+MH  - Temporal Lobe/physiology/physiopathology
+RF  - 92
+EDAT- 2001/02/24 12:00
+MHDA- 2001/03/03 10:01
+CRDT- 2001/02/24 12:00
+PHST- 2001/02/24 12:00 [pubmed]
+PHST- 2001/03/03 10:01 [medline]
+PHST- 2001/02/24 12:00 [entrez]
+AID - 10.1016/s0001-6918(00)00062-7 [doi]
+PST - ppublish
+SO  - Acta Psychol (Amst). 2000 Dec;105(2-3):211-35. doi: 10.1016/s0001-6918(00)00062-7.
+
+PMID- 27450303
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20170901
+LR  - 20181202
+IS  - 1525-5069 (Electronic)
+IS  - 1525-5050 (Linking)
+VI  - 62
+DP  - 2016 Sep
+TI  - An improved qEEG index for asymmetry detection during the Wada test.
+PG  - 40-6
+LID - S1525-5050(16)30164-0 [pii]
+LID - 10.1016/j.yebeh.2016.06.009 [doi]
+AB  - The Wada test is commonly used to evaluate language and memory lateralization in 
+      candidates for epilepsy surgery. The spatial Brain Symmetry Index (BSI) quantifies 
+      inter-hemispheric differences in the EEG. Its application has been shown to be 
+      feasible during Wada testing. We developed a method for the quantification of EEG 
+      asymmetry that matches visual assessments of the EEG better than BSI. Fifty-three 
+      patients' EEG data, with a total of 85 injections were analyzed. In a step-wise, 
+      data-driven manner, multiple electrode and frequency band combinations were 
+      evaluated. Eventually, BSI, calculated using only the frontal electrodes F3 and F4, 
+      was combined with a temporal measure of delta power in the central electrodes, C3 
+      and C4, into a new measure: cBSI. Using the area under the ROC curve (AUC), we 
+      showed that cBSI performs significantly better relative to BSI (median AUC 0.98 
+      versus 0.96, p=0.0015, Wilcoxon signed rank test). Our results showed that asymmetry 
+      detection was significantly improved by combining temporal with spatial qEEG 
+      measures. In the future, our combined qEEG measure could allow for a more objective 
+      way of monitoring EEG asymmetry, thereby increasing the feasibility of using EEG as 
+      a monitoring tool during the Wada test. Future studies should, however, validate our 
+      cBSI method in real time in the operating room or radiology suite.
+CI  - Copyright © 2016 Elsevier Inc. All rights reserved.
+FAU - Bogaarts, Guy
+AU  - Bogaarts G
+AD  - Department of Clinical Neurophysiology, AZM Maastricht, Netherlands. Electronic 
+      address: guybogaarts@gmail.com.
+FAU - Gommer, Erik
+AU  - Gommer E
+AD  - Department of Clinical Neurophysiology, AZM Maastricht, Netherlands.
+FAU - Hilkman, Danny
+AU  - Hilkman D
+AD  - Department of Clinical Neurophysiology, AZM Maastricht, Netherlands.
+FAU - van Kranen-Mastenbroek, Vivianne
+AU  - van Kranen-Mastenbroek V
+AD  - Department of Clinical Neurophysiology, AZM Maastricht, Netherlands.
+FAU - Reulen, Jos
+AU  - Reulen J
+AD  - Department of Clinical Neurophysiology, AZM Maastricht, Netherlands.
+LA  - eng
+PT  - Journal Article
+DEP - 20160720
+PL  - United States
+TA  - Epilepsy Behav
+JT  - Epilepsy & behavior : E&B
+JID - 100892858
+SB  - IM
+MH  - Adult
+MH  - Brain/*physiopathology
+MH  - Electrodes
+MH  - Electroencephalography/*methods
+MH  - Epilepsy/*physiopathology/surgery
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - *Language
+MH  - Male
+MH  - Memory/*physiology
+MH  - Middle Aged
+MH  - Monitoring, Physiologic
+MH  - Young Adult
+OTO - NOTNLM
+OT  - *Brain symmetry index
+OT  - *Epilepsy surgery
+OT  - *Intracarotid amobarbital procedure
+OT  - *Neuromonitoring
+OT  - *Quantitative electroencephalography
+OT  - *Wada test
+EDAT- 2016/07/28 06:00
+MHDA- 2017/09/02 06:00
+CRDT- 2016/07/25 06:00
+PHST- 2016/02/12 00:00 [received]
+PHST- 2016/06/10 00:00 [revised]
+PHST- 2016/06/13 00:00 [accepted]
+PHST- 2016/07/25 06:00 [entrez]
+PHST- 2016/07/28 06:00 [pubmed]
+PHST- 2017/09/02 06:00 [medline]
+AID - S1525-5050(16)30164-0 [pii]
+AID - 10.1016/j.yebeh.2016.06.009 [doi]
+PST - ppublish
+SO  - Epilepsy Behav. 2016 Sep;62:40-6. doi: 10.1016/j.yebeh.2016.06.009. Epub 2016 Jul 
+      20.
+
+PMID- 20136220
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20100624
+LR  - 20181113
+IS  - 1520-8524 (Electronic)
+IS  - 0001-4966 (Print)
+IS  - 0001-4966 (Linking)
+VI  - 127
+IP  - 2
+DP  - 2010 Feb
+TI  - Effects of simulated spectral holes on speech intelligibility and spatial release 
+      from masking under binaural and monaural listening.
+PG  - 977-89
+LID - 10.1121/1.3273897 [doi]
+AB  - The possibility that "dead regions" or "spectral holes" can account for some 
+      differences in performance between bilateral cochlear implant (CI) users and 
+      normal-hearing listeners was explored. Using a 20-band noise-excited vocoder to 
+      simulate CI processing, this study examined effects of spectral holes on speech 
+      reception thresholds (SRTs) and spatial release from masking (SRM) in difficult 
+      listening conditions. Prior to processing, stimuli were convolved through 
+      head-related transfer-functions to provide listeners with free-field directional 
+      cues. Processed stimuli were presented over headphones under binaural or monaural 
+      (right ear) conditions. Using Greenwood's [(1990). J. Acoust. Soc. Am. 87, 
+      2592-2605] frequency-position function and assuming a cochlear length of 35 mm, 
+      spectral holes were created for variable sizes (6 and 10 mm) and locations (base, 
+      middle, and apex). Results show that middle-frequency spectral holes were the most 
+      disruptive to SRTs, whereas high-frequency spectral holes were the most disruptive 
+      to SRM. Spectral holes generally reduced binaural advantages in difficult listening 
+      conditions. These results suggest the importance of measuring dead regions in CI 
+      users. It is possible that customized programming for bilateral CI processors based 
+      on knowledge about dead regions can enhance performance in adverse listening 
+      situations.
+FAU - Garadat, Soha N
+AU  - Garadat SN
+AD  - Waisman Center, University of Wisconsin, 1500 Highland Avenue, Madison, Wisconsin 
+      53705, USA.
+FAU - Litovsky, Ruth Y
+AU  - Litovsky RY
+FAU - Yu, Gongqiang
+AU  - Yu G
+FAU - Zeng, Fan-Gang
+AU  - Zeng FG
+LA  - eng
+GR  - R01 DC003083/DC/NIDCD NIH HHS/United States
+GR  - R29 DC003083/DC/NIDCD NIH HHS/United States
+GR  - R01DC030083/DC/NIDCD NIH HHS/United States
+PT  - Journal Article
+PT  - Research Support, N.I.H., Extramural
+TA  - J Acoust Soc Am
+JT  - The Journal of the Acoustical Society of America
+JID - 7503051
+SB  - IM
+CIN - (1990). J. Acoust. Soc. Am. 87, 2592–2605. PMID: 2373794
+MH  - Acoustic Stimulation
+MH  - Adult
+MH  - Auditory Threshold
+MH  - Cochlea/anatomy & histology
+MH  - *Cochlear Implants
+MH  - Cues
+MH  - *Ear
+MH  - Female
+MH  - *Functional Laterality
+MH  - Head
+MH  - Humans
+MH  - Male
+MH  - Psychoacoustics
+MH  - Space Perception
+MH  - *Speech
+MH  - *Speech Perception
+MH  - Young Adult
+PMC - PMC2830263
+EDAT- 2010/02/09 06:00
+MHDA- 2010/06/25 06:00
+CRDT- 2010/02/09 06:00
+PHST- 2010/02/09 06:00 [entrez]
+PHST- 2010/02/09 06:00 [pubmed]
+PHST- 2010/06/25 06:00 [medline]
+AID - 012002JAS [pii]
+AID - 10.1121/1.3273897 [doi]
+PST - ppublish
+SO  - J Acoust Soc Am. 2010 Feb;127(2):977-89. doi: 10.1121/1.3273897.
+
+PMID- 16054741
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20060110
+LR  - 20061115
+IS  - 0278-2626 (Print)
+IS  - 0278-2626 (Linking)
+VI  - 59
+IP  - 2
+DP  - 2005 Nov
+TI  - Are there pre-existing neural, cognitive, or motoric markers for musical ability?
+PG  - 124-34
+AB  - Adult musician's brains show structural enlargements, but it is not known whether 
+      these are inborn or a consequence of long-term training. In addition, music training 
+      in childhood has been shown to have positive effects on visual-spatial and verbal 
+      outcomes. However, it is not known whether pre-existing advantages in these skills 
+      are found in children who choose to study a musical instrument nor is it known 
+      whether there are pre-existing associations between music and any of these outcome 
+      measures that could help explain the training effects. To answer these questions, we 
+      compared 5- to 7-year-olds beginning piano or string lessons (n=39) with 5- to 
+      7-year-olds not beginning instrumental training (n=31). All children received a 
+      series of tests (visual-spatial, non-verbal reasoning, verbal, motor, and musical) 
+      and underwent magnetic resonance imaging. We found no pre-existing neural, 
+      cognitive, motor, or musical differences between groups and no correlations (after 
+      correction for multiple analyses) between music perceptual skills and any brain or 
+      visual-spatial measures. However, correlations were found between music perceptual 
+      skills and both non-verbal reasoning and phonemic awareness. Such pre-existing 
+      correlations suggest similarities in auditory and visual pattern recognition as well 
+      a sharing of the neural substrates for language and music processing, most likely 
+      due to innate abilities or implicit learning during early development. This baseline 
+      study lays the groundwork for an ongoing longitudinal study addressing the effects 
+      of intensive musical training on brain and cognitive development, and making it 
+      possible to look retroactively at the brain and cognitive development of those 
+      children who emerge showing exceptional musical talent.
+FAU - Norton, Andrea
+AU  - Norton A
+AD  - Department of Neurology, Beth Israel Deaconess Medical Center, Harvard Medical 
+      School, USA.
+FAU - Winner, Ellen
+AU  - Winner E
+FAU - Cronin, Karl
+AU  - Cronin K
+FAU - Overy, Katie
+AU  - Overy K
+FAU - Lee, Dennis J
+AU  - Lee DJ
+FAU - Schlaug, Gottfried
+AU  - Schlaug G
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+PT  - Research Support, U.S. Gov't, Non-P.H.S.
+DEP - 20050728
+PL  - United States
+TA  - Brain Cogn
+JT  - Brain and cognition
+JID - 8218014
+SB  - IM
+MH  - Awareness/physiology
+MH  - Child
+MH  - Choice Behavior
+MH  - Cognition/*physiology
+MH  - Female
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - Magnetic Resonance Imaging
+MH  - Male
+MH  - Motor Cortex/*anatomy & histology/*physiology
+MH  - *Music
+MH  - Nerve Net/*physiology
+MH  - Neuropsychological Tests
+MH  - Phonetics
+MH  - *Psychomotor Performance
+MH  - Space Perception
+MH  - Visual Perception/physiology
+EDAT- 2005/08/02 09:00
+MHDA- 2006/01/13 09:00
+CRDT- 2005/08/02 09:00
+PHST- 2004/11/17 00:00 [received]
+PHST- 2005/03/24 00:00 [revised]
+PHST- 2005/05/29 00:00 [accepted]
+PHST- 2005/08/02 09:00 [pubmed]
+PHST- 2006/01/13 09:00 [medline]
+PHST- 2005/08/02 09:00 [entrez]
+AID - S0278-2626(05)00089-8 [pii]
+AID - 10.1016/j.bandc.2005.05.009 [doi]
+PST - ppublish
+SO  - Brain Cogn. 2005 Nov;59(2):124-34. doi: 10.1016/j.bandc.2005.05.009. Epub 2005 Jul 
+      28.
+
+PMID- 6839069
+OWN - NLM
+STAT- MEDLINE
+DCOM- 19830610
+LR  - 20190705
+IS  - 0007-1250 (Print)
+IS  - 0007-1250 (Linking)
+VI  - 142
+DP  - 1983 Feb
+TI  - The relationship of handedness to the cognitive, language, and visuo-spatial skills 
+      of autistic patients.
+PG  - 156-62
+AB  - The relationship between hand preference, age, and developmental functioning was 
+      examined in 70 autistic patients. Unilateral or mixed handedness appeared to be 
+      stabilized by the age of five years. Patients with established hand lateralization 
+      tended to function better in all developmental areas including intelligence, 
+      language, and visuospatial abilities. It is a tenable hypothesis that the presence 
+      or absence of hand lateralization by age five may be an important predictor of 
+      outcome in autism.
+FAU - Tsai, L Y
+AU  - Tsai LY
+LA  - eng
+PT  - Journal Article
+PL  - England
+TA  - Br J Psychiatry
+JT  - The British journal of psychiatry : the journal of mental science
+JID - 0342367
+SB  - IM
+MH  - Adolescent
+MH  - Age Factors
+MH  - Autistic Disorder/*psychology
+MH  - Child
+MH  - Child Development
+MH  - Child, Preschool
+MH  - Cognition
+MH  - Female
+MH  - *Functional Laterality
+MH  - Humans
+MH  - Intelligence
+MH  - Language Development
+MH  - Male
+EDAT- 1983/02/01 00:00
+MHDA- 1983/02/01 00:01
+CRDT- 1983/02/01 00:00
+PHST- 1983/02/01 00:00 [pubmed]
+PHST- 1983/02/01 00:01 [medline]
+PHST- 1983/02/01 00:00 [entrez]
+AID - S0007125000114382 [pii]
+AID - 10.1192/bjp.142.2.156 [doi]
+PST - ppublish
+SO  - Br J Psychiatry. 1983 Feb;142:156-62. doi: 10.1192/bjp.142.2.156.
+
+PMID- 26866655
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20171222
+LR  - 20191210
+IS  - 1939-1285 (Electronic)
+IS  - 0278-7393 (Linking)
+VI  - 42
+IP  - 8
+DP  - 2016 Aug
+TI  - A general valence asymmetry in similarity: Good is more alike than bad.
+PG  - 1171-92
+LID - 10.1037/xlm0000243 [doi]
+AB  - The density hypothesis (Unkelbach, Fiedler, Bayer, Stegmüller, & Danner, 2008) 
+      claims a general higher similarity of positive information to other positive 
+      information compared with the similarity of negative information to other negative 
+      information. This similarity asymmetry might explain valence asymmetries on all 
+      levels of cognitive processing. The available empirical evidence for this general 
+      valence asymmetry in similarity suffers from a lack of direct tests, low 
+      representativeness, and possible confounding variables (e.g., differential valence 
+      intensity, frequency, familiarity, or concreteness of positive and negative 
+      stimuli). To address these problems, Study 1 first validated the spatial arrangement 
+      method (SpAM) as a similarity measure. Using SpAM, Studies 2-6 found the proposed 
+      valence asymmetry in large, representative samples of self- and other-generated 
+      words (Studies 2a/2b), for words of consensual and idiosyncratic valence (Study 3), 
+      for words from 1 and many independent information sources (Study 4), for real-life 
+      experiences (Study 5), and for large data sets of verbal (i.e., ∼14,000 words 
+      reported by Warriner, Kuperman, & Brysbaert, 2013) and visual information (i.e., 
+      ∼1,000 pictures reported in the IAPS; Lang, Bradley, & Cuthbert, 2005; Study 6). 
+      Together, these data support a general valence asymmetry in similarity, namely that 
+      good is more alike than bad. (PsycINFO Database Record
+CI  - (c) 2016 APA, all rights reserved).
+FAU - Koch, Alex
+AU  - Koch A
+AD  - Social Cognition Center Cologne, University of Cologne.
+FAU - Alves, Hans
+AU  - Alves H
+AD  - Social Cognition Center Cologne, University of Cologne.
+FAU - Krüger, Tobias
+AU  - Krüger T
+AD  - University of Heidelberg.
+FAU - Unkelbach, Christian
+AU  - Unkelbach C
+AD  - Social Cognition Center Cologne, University of Cologne.
+LA  - eng
+PT  - Journal Article
+DEP - 20160211
+PL  - United States
+TA  - J Exp Psychol Learn Mem Cogn
+JT  - Journal of experimental psychology. Learning, memory, and cognition
+JID - 8207540
+SB  - IM
+MH  - Affect/*physiology
+MH  - Analysis of Variance
+MH  - Cognition
+MH  - Emotions/*physiology
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Male
+MH  - Photic Stimulation
+MH  - Reading
+MH  - Recognition, Psychology/*physiology
+MH  - Regression Analysis
+MH  - Semantics
+MH  - Students
+MH  - Universities
+MH  - Vocabulary
+EDAT- 2016/02/13 06:00
+MHDA- 2017/12/23 06:00
+CRDT- 2016/02/12 06:00
+PHST- 2016/02/12 06:00 [entrez]
+PHST- 2016/02/13 06:00 [pubmed]
+PHST- 2017/12/23 06:00 [medline]
+AID - 2016-07251-001 [pii]
+AID - 10.1037/xlm0000243 [doi]
+PST - ppublish
+SO  - J Exp Psychol Learn Mem Cogn. 2016 Aug;42(8):1171-92. doi: 10.1037/xlm0000243. Epub 
+      2016 Feb 11.
+
+PMID- 10929269
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20001207
+LR  - 20190831
+IS  - 0340-5354 (Print)
+IS  - 0340-5354 (Linking)
+VI  - 247
+IP  - 6
+DP  - 2000 Jun
+TI  - Semantic dementia: clinical, radiological and pathological perspectives.
+PG  - 409-22
+AB  - Semantic dementia (SD) is a recently described clinical syndrome characterised by an 
+      acquired progressive inability to name or comprehend common concepts, with little or 
+      no distortion of the phonological and syntactic aspects of language, and relative 
+      sparing of other aspects of cognition, such as episodic memory, nonverbal 
+      problem-solving, and perceptual and visuo-spatial skills. The cognitive locus of 
+      this syndrome appears to lie in the permanent store of long-term memory representing 
+      general world knowledge-semantic memory. The anatomical distribution of atrophy is 
+      less well-defined, and the contribution of various imaging modalities is discussed 
+      in the context of a body of 45 published and unpublished cases. We conclude that 
+      involvement of the left infero-lateral temporal cortex is the critical area in the 
+      genesis of SD. SD probably always represents a non-Alzheimer neurodegenerative 
+      process; a variety of pathological lesions may be present, and possible causes, 
+      together with debates about their correct classification, are discussed.
+FAU - Garrard, P
+AU  - Garrard P
+AD  - University of Cambridge Neurology Unit, Addenbrooke's Hospital, Cambridge, UK.
+FAU - Hodges, J R
+AU  - Hodges JR
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+PT  - Review
+PL  - Germany
+TA  - J Neurol
+JT  - Journal of neurology
+JID - 0423161
+SB  - IM
+MH  - Dementia/diagnostic imaging/*pathology/*physiopathology
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - Language Disorders/diagnostic imaging/pathology/*physiopathology
+MH  - Language Tests
+MH  - Memory Disorders/diagnostic imaging/*pathology/*physiopathology
+MH  - Radiography
+MH  - Temporal Lobe/*pathology/*physiopathology
+RF  - 95
+EDAT- 2000/08/10 11:00
+MHDA- 2001/02/28 10:01
+CRDT- 2000/08/10 11:00
+PHST- 2000/08/10 11:00 [pubmed]
+PHST- 2001/02/28 10:01 [medline]
+PHST- 2000/08/10 11:00 [entrez]
+AID - 10.1007/s004150070169 [doi]
+PST - ppublish
+SO  - J Neurol. 2000 Jun;247(6):409-22. doi: 10.1007/s004150070169.
+
+PMID- 18790081
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20090420
+LR  - 20090112
+IS  - 1525-5069 (Electronic)
+IS  - 1525-5050 (Linking)
+VI  - 14
+IP  - 1
+DP  - 2009 Jan
+TI  - Power spectral density changes and language lateralization during covert object 
+      naming tasks measured with high-density EEG recordings.
+PG  - 54-9
+LID - 10.1016/j.yebeh.2008.08.018 [doi]
+AB  - Our objective was to study changes in EEG time-domain power spectral density (PSDt) 
+      and localization of language areas during covert object naming tasks in human 
+      subjects with epilepsy. EEG data for subjects with epilepsy were acquired during the 
+      covert object naming tasks using a net of 256 electrodes. The trials required each 
+      subject to provide the names of common objects presented every 4 seconds on slides. 
+      Each trial comprised the 1.0 second before and 3.0 seconds after initial object 
+      presentation. PSDt values at baseline and during tasks were calculated in the theta, 
+      alpha, beta, low gamma, and high gamma bands. The spatial contour plots reveal that 
+      PSDt values during object naming were 10-20% higher than the baseline values for 
+      different bands. Language was lateralized to left frontal or temporal areas. In all 
+      cases, the Wada test disclosed language lateralization to the left hemisphere as 
+      well.
+FAU - Ramon, C
+AU  - Ramon C
+AD  - Department of Electrical Engineering, University of Washington, Seattle, WA 98195, 
+      USA. ceon@u.washington.edu
+FAU - Holmes, M
+AU  - Holmes M
+FAU - Freeman, Walter J
+AU  - Freeman WJ
+FAU - Gratkowski, Maciej
+AU  - Gratkowski M
+FAU - Eriksen, K J
+AU  - Eriksen KJ
+FAU - Haueisen, Jens
+AU  - Haueisen J
+LA  - eng
+PT  - Journal Article
+DEP - 20081101
+PL  - United States
+TA  - Epilepsy Behav
+JT  - Epilepsy & behavior : E&B
+JID - 100892858
+SB  - IM
+MH  - Artifacts
+MH  - Brain/*physiology
+MH  - Brain Mapping
+MH  - Data Interpretation, Statistical
+MH  - *Electroencephalography
+MH  - Epilepsy/*psychology
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - *Language
+MH  - Psycholinguistics
+MH  - Psychomotor Performance/physiology
+MH  - Visual Perception/physiology
+EDAT- 2008/09/16 09:00
+MHDA- 2009/04/21 09:00
+CRDT- 2008/09/16 09:00
+PHST- 2008/03/11 00:00 [received]
+PHST- 2008/07/27 00:00 [revised]
+PHST- 2008/08/22 00:00 [accepted]
+PHST- 2008/09/16 09:00 [pubmed]
+PHST- 2009/04/21 09:00 [medline]
+PHST- 2008/09/16 09:00 [entrez]
+AID - S1525-5050(08)00269-2 [pii]
+AID - 10.1016/j.yebeh.2008.08.018 [doi]
+PST - ppublish
+SO  - Epilepsy Behav. 2009 Jan;14(1):54-9. doi: 10.1016/j.yebeh.2008.08.018. Epub 2008 Nov 
+      1.
+
+PMID- 21722656
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20120131
+LR  - 20151119
+IS  - 1873-3514 (Electronic)
+IS  - 0028-3932 (Linking)
+VI  - 49
+IP  - 10
+DP  - 2011 Aug
+TI  - Magical ideation, creativity, handedness, and cerebral asymmetries: a combined 
+      behavioural and fMRI study.
+PG  - 2896-903
+LID - 10.1016/j.neuropsychologia.2011.06.016 [doi]
+AB  - Magical ideation has been shown to be related to measures of hand preference, in 
+      which those with mixed handedness exhibit higher levels of magical ideation than 
+      those with either consistent left- or right-handedness. It is unclear whether the 
+      relation between magical ideation and hand preference is the result of a bias in 
+      questionnaire-taking behaviour or of some neuropsychological concomitant of cerebral 
+      specialization. We sought to replicate this finding and further investigate how 
+      magical ideation is related to other measures of laterality, including handedness 
+      based on finger-tapping performance, and cerebral asymmetries for language, spatial 
+      judgment, and face processing as revealed by fMRI. Creative achievement was also 
+      assessed by questionnaire and correlated with magical ideation and the other 
+      measures. Magical ideation and creativity were positively correlated, and both were 
+      negatively correlated with absolute hand preference but not with hand performance or 
+      with any of the cerebral asymmetries being assessed. The results do not support the 
+      notion that the observed association between magical ideation, creativity and hand 
+      preference has a neuropsychological explanation based on reduced cerebral 
+      lateralization.
+CI  - Copyright © 2011 Elsevier Ltd. All rights reserved.
+FAU - Badzakova-Trajkov, Gjurgjica
+AU  - Badzakova-Trajkov G
+AD  - Research Centre for Cognitive Neuroscience, Department of Psychology, The University 
+      of Auckland, Auckland, New Zealand. g.badzakova@auckland.ac.nz
+FAU - Häberling, Isabelle S
+AU  - Häberling IS
+FAU - Corballis, Michael C
+AU  - Corballis MC
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20110621
+PL  - England
+TA  - Neuropsychologia
+JT  - Neuropsychologia
+JID - 0020713
+SB  - IM
+MH  - Adolescent
+MH  - Adult
+MH  - Cerebral Cortex/*physiology
+MH  - *Creativity
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - *Hand
+MH  - Humans
+MH  - Magic/*psychology
+MH  - *Magnetic Resonance Imaging
+MH  - Male
+MH  - Middle Aged
+MH  - Neuropsychological Tests
+MH  - Psychomotor Performance
+MH  - Surveys and Questionnaires
+MH  - Thinking
+MH  - Young Adult
+EDAT- 2011/07/05 06:00
+MHDA- 2012/02/01 06:00
+CRDT- 2011/07/05 06:00
+PHST- 2010/08/12 00:00 [received]
+PHST- 2011/06/07 00:00 [revised]
+PHST- 2011/06/14 00:00 [accepted]
+PHST- 2011/07/05 06:00 [entrez]
+PHST- 2011/07/05 06:00 [pubmed]
+PHST- 2012/02/01 06:00 [medline]
+AID - S0028-3932(11)00297-1 [pii]
+AID - 10.1016/j.neuropsychologia.2011.06.016 [doi]
+PST - ppublish
+SO  - Neuropsychologia. 2011 Aug;49(10):2896-903. doi: 
+      10.1016/j.neuropsychologia.2011.06.016. Epub 2011 Jun 21.
+
+PMID- 19045830
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20090123
+LR  - 20181113
+IS  - 1751-8849 (Print)
+IS  - 1751-8849 (Linking)
+VI  - 2
+IP  - 5
+DP  - 2008 Sep
+TI  - Virtual Cell modelling and simulation software environment.
+PG  - 352-62
+LID - 10.1049/iet-syb:20080102 [doi]
+AB  - The Virtual Cell (VCell; http://vcell.org/) is a problem solving environment, built 
+      on a central database, for analysis, modelling and simulation of cell biological 
+      processes. VCell integrates a growing range of molecular mechanisms, including 
+      reaction kinetics, diffusion, flow, membrane transport, lateral membrane diffusion 
+      and electrophysiology, and can associate these with geometries derived from 
+      experimental microscope images. It has been developed and deployed as a web-based, 
+      distributed, client-server system, with more than a thousand world-wide users. VCell 
+      provides a separation of layers (core technologies and abstractions) representing 
+      biological models, physical mechanisms, geometry, mathematical models and numerical 
+      methods. This separation clarifies the impact of modelling decisions, assumptions 
+      and approximations. The result is a physically consistent, mathematically rigorous, 
+      spatial modelling and simulation framework. Users create biological models and VCell 
+      will automatically (i) generate the appropriate mathematical encoding for running a 
+      simulation and (ii) generate and compile the appropriate computer code. Both 
+      deterministic and stochastic algorithms are supported for describing and running 
+      non-spatial simulations; a full partial differential equation solver using the 
+      finite volume numerical algorithm is available for reaction-diffusion-advection 
+      simulations in complex cell geometries including 3D geometries derived from 
+      microscope images. Using the VCell database, models and model components can be 
+      reused and updated, as well as privately shared among collaborating groups, or 
+      published. Exchange of models with other tools is possible via import/export of 
+      SBML, CellML and MatLab formats. Furthermore, curation of models is facilitated by 
+      external database binding mechanisms for unique identification of components and by 
+      standardised annotations compliant with the MIRIAM standard. VCell is now open 
+      source, with its native model encoding language (VCML) being a public specification, 
+      which stands as the basis for a new generation of more customised, 
+      experiment-centric modelling tools using a new plug-in based platform.
+FAU - Moraru, I I
+AU  - Moraru II
+AD  - University of Connecticut Health Center, Center of Cell Analysis and Modeling, 
+      Connecticut, CA 06030, USA.
+FAU - Schaff, J C
+AU  - Schaff JC
+FAU - Slepchenko, B M
+AU  - Slepchenko BM
+FAU - Blinov, M L
+AU  - Blinov ML
+FAU - Morgan, F
+AU  - Morgan F
+FAU - Lakshminarayana, A
+AU  - Lakshminarayana A
+FAU - Gao, F
+AU  - Gao F
+FAU - Li, Y
+AU  - Li Y
+FAU - Loew, L M
+AU  - Loew LM
+LA  - eng
+GR  - U54 GM064346-089032/GM/NIGMS NIH HHS/United States
+GR  - P41RR013186/RR/NCRR NIH HHS/United States
+GR  - P41 RR013186-12/RR/NCRR NIH HHS/United States
+GR  - P41 RR013186/RR/NCRR NIH HHS/United States
+GR  - U54 GM064346/GM/NIGMS NIH HHS/United States
+GR  - U54RR022232/RR/NCRR NIH HHS/United States
+GR  - U54 RR022232-04/RR/NCRR NIH HHS/United States
+GR  - U54 RR022232/RR/NCRR NIH HHS/United States
+PT  - Journal Article
+PT  - Research Support, N.I.H., Extramural
+TA  - IET Syst Biol
+JT  - IET systems biology
+JID - 101301198
+RN  - 0 (Proteome)
+SB  - IM
+MH  - Computer Simulation
+MH  - *Databases, Factual
+MH  - Information Storage and Retrieval/methods
+MH  - *Models, Biological
+MH  - Programming Languages
+MH  - Proteome/*metabolism
+MH  - Signal Transduction/*physiology
+MH  - *Software
+MH  - *User-Computer Interface
+PMC - PMC2711391
+MID - NIHMS121244
+EDAT- 2008/12/03 09:00
+MHDA- 2009/01/24 09:00
+CRDT- 2008/12/03 09:00
+PHST- 2008/12/03 09:00 [pubmed]
+PHST- 2009/01/24 09:00 [medline]
+PHST- 2008/12/03 09:00 [entrez]
+AID - 10.1049/iet-syb:20080102 [doi]
+PST - ppublish
+SO  - IET Syst Biol. 2008 Sep;2(5):352-62. doi: 10.1049/iet-syb:20080102.
+
+PMID- 31220770
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20191125
+LR  - 20191125
+IS  - 1873-6297 (Electronic)
+IS  - 0001-6918 (Linking)
+VI  - 198
+DP  - 2019 Jul
+TI  - A replication attempt of hemispheric differences in semantic-relatedness judgments 
+      (Zwaan & Yaxley, 2003).
+PG  - 102871
+LID - S0001-6918(18)30587-0 [pii]
+LID - 10.1016/j.actpsy.2019.102871 [doi]
+AB  - In a study by Zwaan and Yaxley (2003, Cognition, 87, B79-B86), participants judged 
+      the semantic relatedness of word pairs presented one above the other either in the 
+      left or right visual field with all related pairs requiring right-handed responses. 
+      If the vertical orientation of the word pairs matched their referents' typical 
+      vertical orientation ("roof" above "basement") a match effect was observed, but only 
+      when the word pair was presented in the left visual field. We replicated this study 
+      with response side as an additional factor and found a main effect of match, as well 
+      as a Simon effect with faster responses when the required response matched the 
+      visual field in which the word pair was presented. We did not, however, observe an 
+      interaction between the match effect and the visual field. This challenges the 
+      assumption that coarse semantic representations, including spatial properties of 
+      objects, are mainly processed in the right hemisphere.
+CI  - Copyright © 2019 Elsevier B.V. All rights reserved.
+FAU - Berndt, Eduard
+AU  - Berndt E
+AD  - Department of Psychology, University of Tübingen, Tübingen, Germany. Electronic 
+      address: eduard.berndt@uni-tuebingen.de.
+FAU - Dudschig, Carolin
+AU  - Dudschig C
+AD  - Department of Psychology, University of Tübingen, Tübingen, Germany.
+FAU - Miller, Jeff
+AU  - Miller J
+AD  - Department of Psychology, University of Otago, Dunedin, New Zealand.
+FAU - Kaup, Barbara
+AU  - Kaup B
+AD  - Department of Psychology, University of Tübingen, Tübingen, Germany.
+LA  - eng
+PT  - Journal Article
+DEP - 20190617
+PL  - Netherlands
+TA  - Acta Psychol (Amst)
+JT  - Acta psychologica
+JID - 0370366
+SB  - IM
+MH  - Adolescent
+MH  - Adult
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Judgment/*physiology
+MH  - Male
+MH  - Photic Stimulation/methods
+MH  - Reaction Time/*physiology
+MH  - *Semantics
+MH  - Young Adult
+OTO - NOTNLM
+OT  - Embodied cognition
+OT  - Hemispheric differences
+OT  - Language representation
+EDAT- 2019/06/21 06:00
+MHDA- 2019/11/26 06:00
+CRDT- 2019/06/21 06:00
+PHST- 2018/12/21 00:00 [received]
+PHST- 2019/06/04 00:00 [revised]
+PHST- 2019/06/10 00:00 [accepted]
+PHST- 2019/06/21 06:00 [pubmed]
+PHST- 2019/11/26 06:00 [medline]
+PHST- 2019/06/21 06:00 [entrez]
+AID - S0001-6918(18)30587-0 [pii]
+AID - 10.1016/j.actpsy.2019.102871 [doi]
+PST - ppublish
+SO  - Acta Psychol (Amst). 2019 Jul;198:102871. doi: 10.1016/j.actpsy.2019.102871. Epub 
+      2019 Jun 17.
+
+PMID- 8319079
+OWN - NLM
+STAT- MEDLINE
+DCOM- 19930730
+LR  - 20190914
+IS  - 0093-934X (Print)
+IS  - 0093-934X (Linking)
+VI  - 44
+IP  - 4
+DP  - 1993 May
+TI  - Letters as spatial-oriented shapes and/or graphemic signs: a developmental study of 
+      left- and right-handed girls during the period of learning to read.
+PG  - 385-99
+AB  - This study is concerned with the problem of hemispheric specialization and/or 
+      cooperation in relation to development and manual laterality. The processing of 
+      alphabetic signs and its relationship to interhemispheric transfer and functional 
+      hemispheric asymmetries were studied by comparing left- and right-handed girls 
+      during acquisition of reading. The children perform matching tasks with letters 
+      having different orientations and with meaningless forms having the same 
+      orientations as the letters. Each subject performed the matching under three 
+      conditions: right/left intermanual transfer, left/right intermanual transfer, and 
+      dichaptic exploration. Results indicate: (1) A differentiated development between 
+      the two handednesses. (2) The functional lateralization change was different for 
+      left- and right-handed girls, a greater effect of the ability to identify the letter 
+      on matching tasks was observed for the right-handed children than for the 
+      left-handed children. These last results are discussed with regard to 
+      inter-hemispheric transfer and functional hemispheric asymmetry changes. We 
+      hypothesized a strategy difference between left- and right-handed girls and a 
+      difference in their ability to change their cognitive strategy (left-handers 
+      continue to favor a spatial coding with letters).
+FAU - Benoit-Dubrocard, S
+AU  - Benoit-Dubrocard S
+AD  - Université de Provence, Département de Psychophysiologie, URA-CNRS 372, Centre de St 
+      Jérome, Marseille, France.
+FAU - Touche, M E
+AU  - Touche ME
+LA  - eng
+PT  - Comparative Study
+PT  - Journal Article
+PL  - Netherlands
+TA  - Brain Lang
+JT  - Brain and language
+JID - 7506220
+SB  - IM
+MH  - Brain/physiology
+MH  - Child
+MH  - Child Development/physiology
+MH  - Child Language
+MH  - Child, Preschool
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - *Language
+MH  - Language Tests
+MH  - *Learning
+MH  - *Reading
+EDAT- 1993/05/01 00:00
+MHDA- 1993/05/01 00:01
+CRDT- 1993/05/01 00:00
+PHST- 1993/05/01 00:00 [pubmed]
+PHST- 1993/05/01 00:01 [medline]
+PHST- 1993/05/01 00:00 [entrez]
+AID - S0093934X83710230 [pii]
+AID - 10.1006/brln.1993.1023 [doi]
+PST - ppublish
+SO  - Brain Lang. 1993 May;44(4):385-99. doi: 10.1006/brln.1993.1023.
+
+PMID- 23850599
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20140508
+LR  - 20130924
+IS  - 1873-3514 (Electronic)
+IS  - 0028-3932 (Linking)
+VI  - 51
+IP  - 11
+DP  - 2013 Sep
+TI  - Neglect dyslexia: a matter of "good looking".
+PG  - 2109-19
+LID - S0028-3932(13)00229-7 [pii]
+LID - 10.1016/j.neuropsychologia.2013.07.002 [doi]
+AB  - Brain-damaged patients with right-sided unilateral spatial neglect (USN) often make 
+      left-sided errors in reading single words or pseudowords (neglect dyslexia, ND). We 
+      propose that both left neglect and low fixation accuracy account for reading errors 
+      in neglect dyslexia. Eye movements were recorded in USN patients with (ND+) and 
+      without (ND-) neglect dyslexia and in a matched control group of right brain-damaged 
+      patients without neglect (USN-). Unlike ND- and controls, ND+ patients showed left 
+      lateralized omission errors and a distorted eye movement pattern in both a reading 
+      aloud task and a non-verbal saccadic task. During reading, the total number of 
+      fixations was larger in these patients independent of visual hemispace, and most 
+      fixations were inaccurate. Similarly, in the saccadic task only ND+ patients were 
+      unable to reach the moving dot. A third experiment addressed the nature of the left 
+      lateralization in reading error distribution by simulating neglect dyslexia in ND- 
+      patients. ND- and USN- patients had to perform a speeded reading-at-threshold task 
+      that did not allow for eye movements. When stimulus exploration was prevented, ND- 
+      patients, but not controls, produced a pattern of errors similar to that of ND+ with 
+      unlimited exposure time (e.g., left-sided errors). We conclude that neglect dyslexia 
+      reading errors may arise in USN patients as a consequence of an additional and 
+      independent deficit unrelated to the orthographic material. In particular, the 
+      presence of an altered oculo-motor pattern, preventing the automatic execution of 
+      the fine saccadic eye movements involved in reading, uncovers, in USN patients, the 
+      attentional bias also in reading single centrally presented words.
+CI  - © 2013 Elsevier Ltd. All rights reserved.
+FAU - Primativo, Silvia
+AU  - Primativo S
+AD  - Department of Psychology, Sapienza University of Rome, Via dei Marsi, 78, 00100, 
+      Rome, Italy; Neuropsychology Unit, IRCCS Fondazione Santa Lucia, Via Ardeatina, 306, 
+      00100, Rome, Italy. Electronic address: silvia.primativo@uniroma1.it.
+FAU - Arduino, Lisa S
+AU  - Arduino LS
+FAU - De Luca, Maria
+AU  - De Luca M
+FAU - Daini, Roberta
+AU  - Daini R
+FAU - Martelli, Marialuisa
+AU  - Martelli M
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20130710
+PL  - England
+TA  - Neuropsychologia
+JT  - Neuropsychologia
+JID - 0020713
+SB  - IM
+MH  - Aged
+MH  - Aged, 80 and over
+MH  - Attention/physiology
+MH  - Dyslexia/*physiopathology
+MH  - Eye Movements/*physiology
+MH  - Female
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - Male
+MH  - Middle Aged
+MH  - Perceptual Disorders/*physiopathology
+MH  - *Reading
+MH  - Space Perception/physiology
+MH  - Visual Fields/physiology
+OTO - NOTNLM
+OT  - Eye movements
+OT  - Neglect
+OT  - Neglect dyslexia
+OT  - Reading
+EDAT- 2013/07/16 06:00
+MHDA- 2014/05/09 06:00
+CRDT- 2013/07/16 06:00
+PHST- 2012/12/05 00:00 [received]
+PHST- 2013/06/27 00:00 [revised]
+PHST- 2013/07/01 00:00 [accepted]
+PHST- 2013/07/16 06:00 [entrez]
+PHST- 2013/07/16 06:00 [pubmed]
+PHST- 2014/05/09 06:00 [medline]
+AID - S0028-3932(13)00229-7 [pii]
+AID - 10.1016/j.neuropsychologia.2013.07.002 [doi]
+PST - ppublish
+SO  - Neuropsychologia. 2013 Sep;51(11):2109-19. doi: 
+      10.1016/j.neuropsychologia.2013.07.002. Epub 2013 Jul 10.
+
+PMID- 8862845
+OWN - NLM
+STAT- MEDLINE
+DCOM- 19970106
+LR  - 20190830
+IS  - 0317-1671 (Print)
+IS  - 0317-1671 (Linking)
+VI  - 23
+IP  - 3
+DP  - 1996 Aug
+TI  - Functional MRI localization of language in a 9-year-old child.
+PG  - 213-9
+AB  - BACKGROUND: Localizing critical brain functions such as language in children is 
+      difficult and generally requires invasive techniques. Recently sensory, motor and 
+      language functions in adults have been mapped to specific brain locations using 
+      functional imaging techniques. Of these techniques, functional MRI (fMRI) is the 
+      least invasive and has the highest spatial and temporal resolution. Its use in 
+      adults is well documented but application to children has not been as well 
+      described. In the present study lateralization and localization of language was 
+      evaluated with fMRI prior to epilepsy surgery in a nine-year-old male with complex 
+      partial seizures, attentional difficulty and decreased verbal proficiency. METHODS: 
+      Two language paradigms well studied in adults (read, verb generation) and two 
+      additional language paradigms (antonym generation, latter fluency) were studied 
+      using whole brain fMRI after stimulus items and timing were adjusted to achieve the 
+      desired performance level during imaging. The patient was also conditioned to the 
+      magnet environment prior to imaging. RESULTS: Word reading and letter fluency tasks 
+      produced lateralized and localized activation similar to that seen in adults. The 
+      patient had no language deficits following an anterior 2/3 dominant temporal lobe 
+      resection. CONCLUSIONS: With modifications of protocols such as those detailed in 
+      this report, this non-invasive method for localizing language function is feasible 
+      for the presurgical evaluation of children as well being applicable for a variety of 
+      developmental language issues.
+FAU - Benson, R R
+AU  - Benson RR
+AD  - Department of Neurology, Massachusetts General Hospital, Boston 02129-2060, USA.
+FAU - Logan, W J
+AU  - Logan WJ
+FAU - Cosgrove, G R
+AU  - Cosgrove GR
+FAU - Cole, A J
+AU  - Cole AJ
+FAU - Jiang, H
+AU  - Jiang H
+FAU - LeSueur, L L
+AU  - LeSueur LL
+FAU - Buchbinder, B R
+AU  - Buchbinder BR
+FAU - Rosen, B R
+AU  - Rosen BR
+FAU - Caviness, V S Jr
+AU  - Caviness VS Jr
+LA  - eng
+PT  - Case Reports
+PT  - Journal Article
+PL  - England
+TA  - Can J Neurol Sci
+JT  - The Canadian journal of neurological sciences. Le journal canadien des sciences 
+      neurologiques
+JID - 0415227
+SB  - IM
+MH  - Brain/*physiology
+MH  - Brain Mapping
+MH  - Child
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - *Language
+MH  - Magnetic Resonance Imaging
+MH  - Male
+MH  - Photic Stimulation
+EDAT- 1996/08/01 00:00
+MHDA- 2001/03/28 10:01
+CRDT- 1996/08/01 00:00
+PHST- 1996/08/01 00:00 [pubmed]
+PHST- 2001/03/28 10:01 [medline]
+PHST- 1996/08/01 00:00 [entrez]
+AID - 10.1017/s0317167100038543 [doi]
+PST - ppublish
+SO  - Can J Neurol Sci. 1996 Aug;23(3):213-9. doi: 10.1017/s0317167100038543.
+
+PMID- 20727412
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20110119
+LR  - 20181113
+IS  - 1095-9572 (Electronic)
+IS  - 1053-8119 (Print)
+IS  - 1053-8119 (Linking)
+VI  - 54
+IP  - 1
+DP  - 2011 Jan 1
+TI  - Symbolic representations in motor sequence learning.
+PG  - 417-26
+LID - 10.1016/j.neuroimage.2010.08.019 [doi]
+AB  - It has been shown that varying the spatial versus symbolic nature of stimulus 
+      presentation and response production, which affects stimulus-response (S-R) mapping 
+      requirements, influences the magnitude of implicit sequence learning (Koch and 
+      Hoffman, 2000). Here, we evaluated how spatial and symbolic stimuli and responses 
+      affect the neural bases of sequence learning. We selectively eliminated the spatial 
+      component of stimulus presentation (spatial vs. symbolic), response execution 
+      (manual vs. vocal), or both. Fourteen participants performed the alternating serial 
+      reaction time task under these conditions in an MRI scanner, with interleaved 
+      acquisition to allow for recording of vocal response reaction times. Nine regions of 
+      interest (ROIs) were selected to test the hypothesis that the dorsolateral 
+      prefrontal cortex (DLPFC) was preferentially engaged for spatially cued conditions 
+      and cerebellum lobule HVI, crus I and II were associated with symbolically cued 
+      learning. We found that the left cerebellum lobule HVI was selectively recruited for 
+      symbolic learning and the percent signal change in this region was correlated with 
+      learning magnitude under the symbolic conditions. In contrast, the DLPFC did not 
+      exhibit selective activation for learning under spatial conditions. The inferior 
+      parietal lobule exhibited increased activation during learning regardless of the 
+      condition, supporting its role in forming an abstract representation of learned 
+      sequences. These findings reveal different brain networks that are flexibly engaged 
+      depending on the conditions of sequence learning.
+CI  - Copyright © 2010 Elsevier Inc. All rights reserved.
+FAU - Bo, J
+AU  - Bo J
+AD  - School of Kinesiology, University of Michigan, Ann Arbor, MI 48109-1109, USA.
+FAU - Peltier, S J
+AU  - Peltier SJ
+FAU - Noll, D C
+AU  - Noll DC
+FAU - Seidler, R D
+AU  - Seidler RD
+LA  - eng
+GR  - R01 AG024106/AG/NIA NIH HHS/United States
+GR  - R01 AG024106-04S1/AG/NIA NIH HHS/United States
+GR  - AG024106/AG/NIA NIH HHS/United States
+PT  - Journal Article
+PT  - Research Support, N.I.H., Extramural
+DEP - 20100818
+TA  - Neuroimage
+JT  - NeuroImage
+JID - 9215515
+SB  - IM
+MH  - Adult
+MH  - Brain/*physiology
+MH  - Brain Mapping/methods
+MH  - Cerebellum/*physiology
+MH  - Female
+MH  - Fixation, Ocular/physiology
+MH  - Frontal Lobe/physiology
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - Learning/*physiology
+MH  - Magnetic Resonance Imaging/*methods
+MH  - Male
+MH  - Nerve Net/*physiology
+MH  - Parietal Lobe/physiology
+MH  - Reaction Time/*physiology
+MH  - Sequence Analysis/methods
+MH  - Space Perception
+MH  - Speech
+MH  - Symbolism
+MH  - Young Adult
+PMC - PMC2962690
+MID - NIHMS231449
+EDAT- 2010/08/24 06:00
+MHDA- 2011/01/20 06:00
+CRDT- 2010/08/24 06:00
+PHST- 2010/06/07 00:00 [received]
+PHST- 2010/07/23 00:00 [revised]
+PHST- 2010/08/10 00:00 [accepted]
+PHST- 2010/08/24 06:00 [entrez]
+PHST- 2010/08/24 06:00 [pubmed]
+PHST- 2011/01/20 06:00 [medline]
+AID - S1053-8119(10)01101-8 [pii]
+AID - 10.1016/j.neuroimage.2010.08.019 [doi]
+PST - ppublish
+SO  - Neuroimage. 2011 Jan 1;54(1):417-26. doi: 10.1016/j.neuroimage.2010.08.019. Epub 
+      2010 Aug 18.
+
+PMID- 27001861
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20161213
+LR  - 20181113
+IS  - 1091-6490 (Electronic)
+IS  - 0027-8424 (Print)
+IS  - 0027-8424 (Linking)
+VI  - 113
+IP  - 14
+DP  - 2016 Apr 5
+TI  - Spatiotemporal dynamics of auditory attention synchronize with speech.
+PG  - 3873-8
+LID - 10.1073/pnas.1523357113 [doi]
+AB  - Attention plays a fundamental role in selectively processing stimuli in our 
+      environment despite distraction. Spatial attention induces increasing and decreasing 
+      power of neural alpha oscillations (8-12 Hz) in brain regions ipsilateral and 
+      contralateral to the locus of attention, respectively. This study tested whether the 
+      hemispheric lateralization of alpha power codes not just the spatial location but 
+      also the temporal structure of the stimulus. Participants attended to spoken digits 
+      presented to one ear and ignored tightly synchronized distracting digits presented 
+      to the other ear. In the magnetoencephalogram, spatial attention induced 
+      lateralization of alpha power in parietal, but notably also in auditory cortical 
+      regions. This alpha power lateralization was not maintained steadily but fluctuated 
+      in synchrony with the speech rate and lagged the time course of low-frequency (1-5 
+      Hz) sensory synchronization. Higher amplitude of alpha power modulation at the 
+      speech rate was predictive of a listener's enhanced performance of stream-specific 
+      speech comprehension. Our findings demonstrate that alpha power lateralization is 
+      modulated in tune with the sensory input and acts as a spatiotemporal filter 
+      controlling the read-out of sensory content.
+FAU - Wöstmann, Malte
+AU  - Wöstmann M
+AD  - Department of Psychology, University of Lübeck, 23562 Luebeck, Germany; Max Planck 
+      Research Group "Auditory Cognition," Max Planck Institute for Human Cognitive and 
+      Brain Sciences, 04103 Leipzig, Germany; malte.woestmann@uni-luebeck.de 
+      jonas.obleser@uni-luebeck.de.
+FAU - Herrmann, Björn
+AU  - Herrmann B
+AD  - Max Planck Research Group "Auditory Cognition," Max Planck Institute for Human 
+      Cognitive and Brain Sciences, 04103 Leipzig, Germany; Department of Psychology, The 
+      University of Western Ontario, London, Canada N6A 5C2;
+FAU - Maess, Burkhard
+AU  - Maess B
+AD  - Magnetoencephalography and Cortical Networks Unit, Max Planck Institute for Human 
+      Cognitive and Brain Sciences, 04103 Leipzig, Germany.
+FAU - Obleser, Jonas
+AU  - Obleser J
+AUID- ORCID: 0000-0002-7619-0459
+AD  - Department of Psychology, University of Lübeck, 23562 Luebeck, Germany; Max Planck 
+      Research Group "Auditory Cognition," Max Planck Institute for Human Cognitive and 
+      Brain Sciences, 04103 Leipzig, Germany; malte.woestmann@uni-luebeck.de 
+      jonas.obleser@uni-luebeck.de.
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20160321
+TA  - Proc Natl Acad Sci U S A
+JT  - Proceedings of the National Academy of Sciences of the United States of America
+JID - 7505876
+SB  - IM
+MH  - Acoustic Stimulation
+MH  - Adult
+MH  - Attention/*physiology
+MH  - Auditory Cortex/physiology
+MH  - Auditory Perception/*physiology
+MH  - Brain Mapping
+MH  - Brain Waves/*physiology
+MH  - Female
+MH  - Functional Laterality/physiology
+MH  - Hearing/*physiology
+MH  - Humans
+MH  - Magnetoencephalography
+MH  - Male
+MH  - Reaction Time
+MH  - Spatial Behavior/physiology
+MH  - *Spatio-Temporal Analysis
+MH  - Speech/*physiology
+MH  - Speech Perception/*physiology
+MH  - Young Adult
+PMC - PMC4833226
+OTO - NOTNLM
+OT  - alpha lateralization
+OT  - attention
+OT  - neural oscillations
+OT  - speech
+OT  - synchronization
+COIS- The authors declare no conflict of interest.
+EDAT- 2016/03/24 06:00
+MHDA- 2016/12/15 06:00
+CRDT- 2016/03/23 06:00
+PHST- 2016/03/23 06:00 [entrez]
+PHST- 2016/03/24 06:00 [pubmed]
+PHST- 2016/12/15 06:00 [medline]
+AID - 1523357113 [pii]
+AID - 201523357 [pii]
+AID - 10.1073/pnas.1523357113 [doi]
+PST - ppublish
+SO  - Proc Natl Acad Sci U S A. 2016 Apr 5;113(14):3873-8. doi: 10.1073/pnas.1523357113. 
+      Epub 2016 Mar 21.
+
+PMID- 23142349
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20130625
+LR  - 20130111
+IS  - 1873-3514 (Electronic)
+IS  - 0028-3932 (Linking)
+VI  - 51
+IP  - 1
+DP  - 2013 Jan
+TI  - Line bisection error predicts the presence and severity of neglect dyslexia in 
+      paragraph reading.
+PG  - 1-7
+LID - S0028-3932(12)00464-2 [pii]
+LID - 10.1016/j.neuropsychologia.2012.10.026 [doi]
+AB  - Cancellation tasks and line bisection tasks are commonly used to diagnose spatial 
+      neglect after right hemisphere lesions. In such tasks, neglect patients often show 
+      leftsided omissions of targets in cancellation tests as well as a pathological 
+      rightward deviation in horizontal line bisection. However, double dissociations have 
+      also been reported and the relation between performance in both tasks is not clear. 
+      Another impairment frequently associated with the neglect syndrome are omissions or 
+      misread initial letters of single words, a phenomenon termed neglect dyslexia (ND). 
+      Omissions of whole words on the contralesional side of the page are generally 
+      considered as egocentric or space-based errors, whereas misreadings of the left part 
+      of a word in ND can be viewed as a type of stimulus-centered or word-based, 
+      perceptual error. As words, sentences and horizontal lines have a similar spatial 
+      layout in the sense that they all are horizontally aligned, long stimuli with a 
+      canonical left-right orientation (with a defined beginning on the left and an end on 
+      the right side), we hypothesized a significant association between the horizontal 
+      line bisection error (LBE) in neglect and the extent (number) of neglected or 
+      substituted letters within single words in ND (neglect dyslexia extension, NDE). To 
+      this purpose, we computed Center-of-Cancellation (CoC) scores in a cancellation task 
+      as well as Center-of-Reading (CoR) scores in an experimental paragraph reading test. 
+      We found that the CoR was a better indicator for egocentric word omissions than the 
+      CoC in a group of 17 patients with left visuospatial neglect. Furthermore, the LBE 
+      predicted the severity of ND, indicated by highly significant correlations between 
+      the LBE and the extent of the neglected letter string within single words (NDE; 
+      r=0.73, p<0.001) as well as between the LBE and the frequency of ND errors (r=0.61; 
+      p=0.009). In contrast, we found no significant correlation between the CoC and the 
+      severity of ND. These results indicate two different pathological mechanisms being 
+      responsible for contralesional spatial neglect and ND. In conclusion, the LBE is a 
+      more sensitive predictor of the presence and severity of the reading disorder in 
+      spatial neglect than conventional cancellation tasks.
+CI  - Copyright © 2012 Elsevier Ltd. All rights reserved.
+FAU - Reinhart, Stefan
+AU  - Reinhart S
+AD  - Saarland University, Clinical Neuropsychology Unit and Outpatient Service, 
+      Saarbrücken, Germany. s.reinhart@mx.uni-saarland.de
+FAU - Wagner, Prisca
+AU  - Wagner P
+FAU - Schulz, Anna
+AU  - Schulz A
+FAU - Keller, Ingo
+AU  - Keller I
+FAU - Kerkhoff, Georg
+AU  - Kerkhoff G
+LA  - eng
+PT  - Journal Article
+DEP - 20121107
+PL  - England
+TA  - Neuropsychologia
+JT  - Neuropsychologia
+JID - 0020713
+SB  - IM
+MH  - Aged
+MH  - Dyslexia/*complications
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Male
+MH  - Middle Aged
+MH  - Perceptual Disorders/*complications
+MH  - Predictive Value of Tests
+MH  - *Reading
+MH  - Space Perception/physiology
+MH  - Statistics as Topic
+EDAT- 2012/11/13 06:00
+MHDA- 2013/06/26 06:00
+CRDT- 2012/11/13 06:00
+PHST- 2012/06/21 00:00 [received]
+PHST- 2012/10/08 00:00 [revised]
+PHST- 2012/10/30 00:00 [accepted]
+PHST- 2012/11/13 06:00 [entrez]
+PHST- 2012/11/13 06:00 [pubmed]
+PHST- 2013/06/26 06:00 [medline]
+AID - S0028-3932(12)00464-2 [pii]
+AID - 10.1016/j.neuropsychologia.2012.10.026 [doi]
+PST - ppublish
+SO  - Neuropsychologia. 2013 Jan;51(1):1-7. doi: 10.1016/j.neuropsychologia.2012.10.026. 
+      Epub 2012 Nov 7.
+
+PMID- 26011744
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20160218
+LR  - 20181202
+IS  - 1090-2155 (Electronic)
+IS  - 0093-934X (Linking)
+VI  - 147
+DP  - 2015 Aug
+TI  - Right unilateral spatial neglect in aphasic patients.
+PG  - 21-9
+LID - S0093-934X(15)00103-0 [pii]
+LID - 10.1016/j.bandl.2015.05.001 [doi]
+AB  - To investigate spatial responses by aphasic patients during language tasks, 63 
+      aphasics (21 severe, 21 moderate, and 21 mild) were administered two kinds of 
+      auditory pointing tasks-word tasks and sentence tasks-in which the spatial 
+      conditions of the stimuli were controlled. There were significantly fewer correct 
+      responses on the right side of a space than on the left side in both the word and 
+      sentence tasks, but the left deviation of correct responses was more prominent in 
+      the sentence task than in the word task. Additionally, the severe aphasics exhibited 
+      a prominent leftward deviation that may have been the result of deficits in 
+      rightward attention controlled by the left hemisphere. This phenomenon also seems to 
+      reflect the directional attention that is subserved by the right hemisphere, which 
+      attends to the left side of a space and, less predominantly, the right side of a 
+      space.
+CI  - Copyright © 2015 Elsevier Inc. All rights reserved.
+FAU - Ihori, Nami
+AU  - Ihori N
+AD  - Department of Rehabilitation, Kawasaki Cooperative Hospital, 2-1-5 Sakuramoto, 
+      Kawasaki-ku, Kawasaki 210-0833, Japan. Electronic address: ihorinami@aol.com.
+FAU - Kashiwagi, Asako
+AU  - Kashiwagi A
+AD  - Department of Rehabilitation, Kyoritsu Rehabilitation Hospital, 1-39-1 Hirano, 
+      Kawanishi 666-0121, Japan.
+FAU - Kashiwagi, Toshihiro
+AU  - Kashiwagi T
+AD  - Department of Rehabilitation, Nakaya Hospital, 123-1 Narukami, Wakayama 640-8303, 
+      Japan.
+LA  - eng
+PT  - Journal Article
+DEP - 20150523
+PL  - Netherlands
+TA  - Brain Lang
+JT  - Brain and language
+JID - 7506220
+SB  - IM
+MH  - Adult
+MH  - Aged
+MH  - Aged, 80 and over
+MH  - Aphasia/*complications/*physiopathology
+MH  - Attention/physiology
+MH  - Female
+MH  - *Functional Laterality
+MH  - Humans
+MH  - *Language
+MH  - Male
+MH  - Middle Aged
+MH  - Perceptual Disorders/*complications/*physiopathology
+MH  - Vocabulary
+OTO - NOTNLM
+OT  - Aphasic patients
+OT  - Directional attention
+OT  - Language task
+OT  - Left brain damage
+OT  - Leftward deviation
+OT  - Mild aphasia
+OT  - Moderate aphasia
+OT  - Right unilateral spatial neglect
+OT  - Severe aphasia
+EDAT- 2015/05/27 06:00
+MHDA- 2016/02/19 06:00
+CRDT- 2015/05/27 06:00
+PHST- 2014/09/07 00:00 [received]
+PHST- 2015/04/16 00:00 [revised]
+PHST- 2015/05/02 00:00 [accepted]
+PHST- 2015/05/27 06:00 [entrez]
+PHST- 2015/05/27 06:00 [pubmed]
+PHST- 2016/02/19 06:00 [medline]
+AID - S0093-934X(15)00103-0 [pii]
+AID - 10.1016/j.bandl.2015.05.001 [doi]
+PST - ppublish
+SO  - Brain Lang. 2015 Aug;147:21-9. doi: 10.1016/j.bandl.2015.05.001. Epub 2015 May 23.
+
+PMID- 24939724
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20150330
+LR  - 20160511
+IS  - 2158-0022 (Electronic)
+IS  - 2158-0014 (Linking)
+VI  - 4
+IP  - 6
+DP  - 2014 Aug
+TI  - The presupplementary area within the language network: a resting state functional 
+      magnetic resonance imaging functional connectivity analysis.
+PG  - 440-53
+LID - 10.1089/brain.2014.0263 [doi]
+AB  - The presupplementary motor area (pre-SMA) is involved in volitional selection. 
+      Despite the lateralization of the language network and different functions for both 
+      pre-SMA, few studies have reported the lateralization of pre-SMA activity and very 
+      little is known about the possible lateralization of pre-SMA connectivity. Via 
+      functional connectivity analysis, we sought to understand how the language network 
+      may be connected to other intrinsic connectivity networks (ICNs) through the 
+      pre-SMA. We performed a spatial independent component analysis of resting state 
+      functional magnetic resonance imaging in 30 volunteers to identify the language 
+      network. Subsequently, we applied seed-to-voxel functional connectivity analyses 
+      centered on peaks detected in the pre-SMA. Three signal peaks were detected in the 
+      pre-SMA. The left rostral pre-SMA intrinsic connectivity network (LR ICN) was left 
+      lateralized in contrast to bilateral ICNs associated to right pre-SMA peaks. The LR 
+      ICN was anticorrelated with the dorsal attention network and the right caudal 
+      pre-SMA ICN (RC ICN) anticorrelated with the default mode network. These two ICNs 
+      overlapped minimally. In contrast, the right rostral ICN overlapped the LR ICN. Both 
+      right ICNs overlapped in the ventral attention network (vATT). The bilateral 
+      connectivity of the right rostral pre-SMA may allow right hemispheric recruitment to 
+      process semantic ambiguities. Overlap between the right pre-SMA ICNs in vATT may 
+      contribute to internal thought to external environment reorientation. Distinct ICNs 
+      connected to areas involved in lexico-syntactic selection and phonology converge in 
+      the pre-SMA, which may constitute the resolution space of competing condition-action 
+      associations for speech production.
+FAU - Ter Minassian, Aram
+AU  - Ter Minassian A
+AD  - 1 Laboratoire Angevin de Recherche en Ingénierie des Systèmes (LARIS) , Équipe 
+      Information, Signal, Image et Sciences du Vivant (ISISV), Université d'Angers, 
+      Angers, France .
+FAU - Ricalens, Emmanuel
+AU  - Ricalens E
+FAU - Nguyen The Tich, Sylvie
+AU  - Nguyen The Tich S
+FAU - Dinomais, Mickaël
+AU  - Dinomais M
+FAU - Aubé, Christophe
+AU  - Aubé C
+FAU - Beydon, Laurent
+AU  - Beydon L
+LA  - eng
+PT  - Journal Article
+DEP - 20140722
+PL  - United States
+TA  - Brain Connect
+JT  - Brain connectivity
+JID - 101550313
+SB  - IM
+MH  - Adult
+MH  - Attention/physiology
+MH  - Brain/*physiology
+MH  - Brain Mapping
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - *Language
+MH  - Magnetic Resonance Imaging
+MH  - Male
+MH  - Middle Aged
+MH  - Motor Cortex/*physiology
+MH  - Nerve Net/*physiology
+OTO - NOTNLM
+OT  - brain
+OT  - functional connectivity
+OT  - language
+OT  - presupplementary motor area
+OT  - resting state fMRI
+EDAT- 2014/06/19 06:00
+MHDA- 2015/03/31 06:00
+CRDT- 2014/06/19 06:00
+PHST- 2014/06/19 06:00 [entrez]
+PHST- 2014/06/19 06:00 [pubmed]
+PHST- 2015/03/31 06:00 [medline]
+AID - 10.1089/brain.2014.0263 [doi]
+PST - ppublish
+SO  - Brain Connect. 2014 Aug;4(6):440-53. doi: 10.1089/brain.2014.0263. Epub 2014 Jul 22.
+
+PMID- 7960468
+OWN - NLM
+STAT- MEDLINE
+DCOM- 19941205
+LR  - 20190830
+IS  - 0020-7454 (Print)
+IS  - 0020-7454 (Linking)
+VI  - 76
+IP  - 1-2
+DP  - 1994 May
+TI  - Spatial alexia.
+PG  - 49-59
+AB  - Twenty-one patients with right hemisphere damage were studied (11 men, 10 women; 
+      average age = 41.33; range = 19-65). Patients were divided in two groups: 
+      pre-Rolandic (six patients) and retro-Rolandic (15 patients) right hemisphere 
+      damage. A special reading test was given to each patient. The observed errors 
+      included: literal errors (substitutions, additions, and omissions of letters), 
+      substitutions of syllables and pseudowords for meaningful words, left hemispatial 
+      neglect, confabulation, splitting of words, verbal errors (substitutions, additions, 
+      and omission of words), grouping of letters belonging to two different words, misuse 
+      of punctuation marks, and errors in following lines. It was proposed that spatial 
+      alexia is characterized by: (1) some difficulties in the recognition of the spatial 
+      orientation in letters; (2) left hemispatial neglect; (3) tendency to "complete" the 
+      sense of words and sentences; (4) inability to follow lines when reading texts, and 
+      sequentially explore the spatial distribution of the written material; and (5) 
+      grouping and fragmentation of words, most likely as a consequence of the inability 
+      to interpret the relative value of spaces between letters correctly.
+FAU - Ardila, A
+AU  - Ardila A
+AD  - Instituto Colombiano de Neuropsicologia, Bogota.
+FAU - Rosselli, M
+AU  - Rosselli M
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+PL  - England
+TA  - Int J Neurosci
+JT  - The International journal of neuroscience
+JID - 0270707
+SB  - IM
+MH  - Adult
+MH  - Aged
+MH  - Attention
+MH  - Brain Diseases/complications/*diagnosis/physiopathology
+MH  - Colombia/ethnology
+MH  - Dyslexia, Acquired/*diagnosis/etiology/physiopathology
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Language
+MH  - Male
+MH  - Middle Aged
+MH  - Neuropsychological Tests
+MH  - Perceptual Disorders/etiology/physiopathology
+MH  - *Space Perception
+MH  - Spain
+EDAT- 1994/05/01 00:00
+MHDA- 1994/05/01 00:01
+CRDT- 1994/05/01 00:00
+PHST- 1994/05/01 00:00 [pubmed]
+PHST- 1994/05/01 00:01 [medline]
+PHST- 1994/05/01 00:00 [entrez]
+AID - 10.3109/00207459408985991 [doi]
+PST - ppublish
+SO  - Int J Neurosci. 1994 May;76(1-2):49-59. doi: 10.3109/00207459408985991.
+
+PMID- 23921095
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20140625
+LR  - 20131101
+IS  - 1095-9572 (Electronic)
+IS  - 1053-8119 (Linking)
+VI  - 83
+DP  - 2013 Dec
+TI  - Structural white matter asymmetries in relation to functional asymmetries during 
+      speech perception and production.
+PG  - 1088-97
+LID - S1053-8119(13)00845-8 [pii]
+LID - 10.1016/j.neuroimage.2013.07.076 [doi]
+AB  - Functional hemispheric asymmetries of speech production and perception are a key 
+      feature of the human language system, but their neurophysiological basis is still 
+      poorly understood. Using a combined fMRI and tract-based spatial statistics 
+      approach, we investigated the relation of microstructural asymmetries in 
+      language-relevant white matter pathways and functional activation asymmetries during 
+      silent verb generation and passive listening to spoken words. Tract-based spatial 
+      statistics revealed several leftward asymmetric clusters in the arcuate fasciculus 
+      and uncinate fasciculus that were differentially related to activation asymmetries 
+      in the two functional tasks. Frontal and temporal activation asymmetries during 
+      silent verb generation were positively related to the strength of specific 
+      microstructural white matter asymmetries in the arcuate fasciculus. In contrast, 
+      microstructural uncinate fasciculus asymmetries were related to temporal activation 
+      asymmetries during passive listening. These findings suggest that white matter 
+      asymmetries may indeed be one of the factors underlying functional hemispheric 
+      asymmetries. Moreover, they also show that specific localized white matter 
+      asymmetries might be of greater relevance for functional activation asymmetries than 
+      microstructural features of whole pathways.
+CI  - © 2013.
+FAU - Ocklenburg, Sebastian
+AU  - Ocklenburg S
+AD  - Department of Biological and Medical Psychology, University of Bergen, Bergen, 
+      Norway. Electronic address: sebastian.ocklenburg@rub.de.
+FAU - Hugdahl, Kenneth
+AU  - Hugdahl K
+FAU - Westerhausen, René
+AU  - Westerhausen R
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20130803
+PL  - United States
+TA  - Neuroimage
+JT  - NeuroImage
+JID - 9215515
+SB  - IM
+MH  - Adolescent
+MH  - Adult
+MH  - Brain/*cytology/physiology
+MH  - Brain Mapping
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Image Processing, Computer-Assisted
+MH  - Magnetic Resonance Imaging
+MH  - Male
+MH  - Nerve Fibers, Myelinated/physiology/*ultrastructure
+MH  - Speech/*physiology
+MH  - Speech Perception/*physiology
+MH  - Young Adult
+OTO - NOTNLM
+OT  - Arcuate fasciculus
+OT  - Diffusion tensor tractography
+OT  - Functional hemispheric asymmetries
+OT  - Structural hemispheric asymmetries
+OT  - Tract-based spatial statistics
+OT  - Uncinate fasciculus
+EDAT- 2013/08/08 06:00
+MHDA- 2014/06/26 06:00
+CRDT- 2013/08/08 06:00
+PHST- 2013/03/01 00:00 [received]
+PHST- 2013/07/04 00:00 [revised]
+PHST- 2013/07/28 00:00 [accepted]
+PHST- 2013/08/08 06:00 [entrez]
+PHST- 2013/08/08 06:00 [pubmed]
+PHST- 2014/06/26 06:00 [medline]
+AID - S1053-8119(13)00845-8 [pii]
+AID - 10.1016/j.neuroimage.2013.07.076 [doi]
+PST - ppublish
+SO  - Neuroimage. 2013 Dec;83:1088-97. doi: 10.1016/j.neuroimage.2013.07.076. Epub 2013 
+      Aug 3.
+
+PMID- 21429649
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20110912
+LR  - 20110517
+IS  - 1090-2147 (Electronic)
+IS  - 0278-2626 (Linking)
+VI  - 76
+IP  - 2
+DP  - 2011 Jul
+TI  - Effects of attention on dichotic listening in elderly and patients with dementia of 
+      the Alzheimer type.
+PG  - 286-93
+LID - 10.1016/j.bandc.2011.02.008 [doi]
+AB  - This article presents an overview of our studies in elderly and Alzheimer patients 
+      employing Kimura's dichotic digits paradigm as a measure for left hemispheric 
+      predominance for processing language stimuli. In addition to structural brain 
+      mechanisms, we demonstrated that attention modulates the direction and degree of ear 
+      asymmetry in dichotic listening. Elderly showed increasingly more difficulties 
+      focusing attention on the left ear (LE) with advancing age. Alzheimer patients 
+      showed severe deficits to allocate attention to the LE, which could result in a 
+      right ear advantage. These results may be attributed to a breakdown of the cortical 
+      attentional network which is mediated by frontal (inhibitory control of attention) 
+      and parietal regions (spatial attention and 'disengagement processes'). Both 
+      interhemispheric disconnectivity (callosal atrophy) and intrahemispheric 
+      disconnectivity (subcortical white matter lesions) appear to be important factors 
+      contributing to these findings.
+CI  - 2011 Elsevier Inc. All rights reserved.
+FAU - Bouma, Anke
+AU  - Bouma A
+AD  - Department of Clinical and Developmental Neuropsychology, University of Groningen, 
+      Grote Kruisstraat 2/1, 9712 TS Groningen, The Netherlands. j.m.bouma@rug.nl
+FAU - Gootjes, Liselotte
+AU  - Gootjes L
+LA  - eng
+PT  - Journal Article
+PT  - Review
+DEP - 20110322
+PL  - United States
+TA  - Brain Cogn
+JT  - Brain and cognition
+JID - 8218014
+SB  - IM
+MH  - Aged
+MH  - Aged, 80 and over
+MH  - Aging/*physiology
+MH  - Alzheimer Disease/*physiopathology
+MH  - Attention/*physiology
+MH  - Auditory Perception/*physiology
+MH  - Dichotic Listening Tests
+MH  - Functional Laterality/*physiology
+MH  - Humans
+EDAT- 2011/03/25 06:00
+MHDA- 2011/09/13 06:00
+CRDT- 2011/03/25 06:00
+PHST- 2010/12/30 00:00 [received]
+PHST- 2011/02/18 00:00 [revised]
+PHST- 2011/02/18 00:00 [accepted]
+PHST- 2011/03/25 06:00 [entrez]
+PHST- 2011/03/25 06:00 [pubmed]
+PHST- 2011/09/13 06:00 [medline]
+AID - S0278-2626(11)00038-8 [pii]
+AID - 10.1016/j.bandc.2011.02.008 [doi]
+PST - ppublish
+SO  - Brain Cogn. 2011 Jul;76(2):286-93. doi: 10.1016/j.bandc.2011.02.008. Epub 2011 Mar 
+      22.
+
+PMID- 21377668
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20120821
+LR  - 20150708
+IS  - 1973-8102 (Electronic)
+IS  - 0010-9452 (Linking)
+VI  - 48
+IP  - 6
+DP  - 2012 Jun
+TI  - Attention networks and their interactions after right-hemisphere damage.
+PG  - 654-63
+LID - 10.1016/j.cortex.2011.01.009 [doi]
+AB  - Unilateral spatial neglect is a disabling condition, frequently observed after 
+      right-hemisphere damage (RHD), and associated with poor functional recovery. 
+      Clinical and experimental evidence indicates that attentional impairments are 
+      prominent in neglect. Recent brain imaging and behavioral studies in neglect 
+      patients and healthy individuals have provided insights into the mechanisms of 
+      attention and have revealed interactions between putative attentional networks. We 
+      recruited 16 RHD patients and 16 neurologically intact observers to perform a 
+      lateralized version of the Attention Network Test devised by Posner and co-workers 
+      (Fan et al., 2002). The results showed evidence of interaction between attentional 
+      networks during conflict resolution. Phasic alertness improved the orienting deficit 
+      to left-sided targets, reducing the interference of distracters in the neglected 
+      visual field, thus facilitating conflict resolution in the majority of patients. 
+      Modulating alertness may be an important way of improving basic deficits associated 
+      with neglect, such as those affecting spatial orienting.
+CI  - Copyright © 2011 Elsevier Srl. All rights reserved.
+FAU - Chica, Ana B
+AU  - Chica AB
+AD  - INSERM-U975, Centre de Recherche de l'Institut du Cerveau et de la Moëlle Epinière, 
+      Université Pierre et Marie Curie, Groupe Hospitalier Pitié-Salpêtrière, Paris, 
+      France. anachica@ugr.es
+FAU - Thiebaut de Schotten, Michel
+AU  - Thiebaut de Schotten M
+FAU - Toba, Monica
+AU  - Toba M
+FAU - Malhotra, Paresh
+AU  - Malhotra P
+FAU - Lupiáñez, Juan
+AU  - Lupiáñez J
+FAU - Bartolomeo, Paolo
+AU  - Bartolomeo P
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20110203
+PL  - Italy
+TA  - Cortex
+JT  - Cortex; a journal devoted to the study of the nervous system and behavior
+JID - 0100725
+SB  - IM
+MH  - Adult
+MH  - Aged
+MH  - Attention/*physiology
+MH  - Cues
+MH  - Educational Status
+MH  - Female
+MH  - Fixation, Ocular
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Magnetic Resonance Imaging
+MH  - Male
+MH  - Middle Aged
+MH  - Nerve Net/pathology/*physiopathology
+MH  - Neuropsychological Tests
+MH  - Orientation
+MH  - Perceptual Disorders/pathology/*physiopathology/psychology
+MH  - Psychomotor Performance/physiology
+MH  - Reaction Time/physiology
+MH  - Reading
+MH  - Tomography, X-Ray Computed
+EDAT- 2011/03/08 06:00
+MHDA- 2012/08/22 06:00
+CRDT- 2011/03/08 06:00
+PHST- 2010/09/03 00:00 [received]
+PHST- 2010/12/14 00:00 [revised]
+PHST- 2011/01/17 00:00 [accepted]
+PHST- 2011/03/08 06:00 [entrez]
+PHST- 2011/03/08 06:00 [pubmed]
+PHST- 2012/08/22 06:00 [medline]
+AID - S0010-9452(11)00023-2 [pii]
+AID - 10.1016/j.cortex.2011.01.009 [doi]
+PST - ppublish
+SO  - Cortex. 2012 Jun;48(6):654-63. doi: 10.1016/j.cortex.2011.01.009. Epub 2011 Feb 3.
+
+PMID- 29878073
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20191010
+LR  - 20191010
+IS  - 1460-2199 (Electronic)
+IS  - 1047-3211 (Print)
+IS  - 1047-3211 (Linking)
+VI  - 28
+IP  - 8
+DP  - 2018 Aug 1
+TI  - The Ventral Anterior Temporal Lobe has a Necessary Role in Exception Word Reading.
+PG  - 3035-3045
+LID - 10.1093/cercor/bhy131 [doi]
+AB  - An influential account of reading holds that words with exceptional 
+      spelling-to-sound correspondences (e.g., PINT) are read via activation of their 
+      lexical-semantic representations, supported by the anterior temporal lobe (ATL). 
+      This account has been inconclusive because it is based on neuropsychological 
+      evidence, in which lesion-deficit relationships are difficult to localize precisely, 
+      and functional neuroimaging data, which is spatially precise but cannot demonstrate 
+      whether the ATL activity is necessary for exception word reading. To address these 
+      issues, we used a technique with good spatial specificity-repetitive transcranial 
+      magnetic stimulation (rTMS)-to demonstrate a necessary role of ATL in exception word 
+      reading. Following rTMS to left ventral ATL, healthy Japanese adults made more 
+      regularization errors in reading Japanese exception words. We successfully simulated 
+      these results in a computational model in which exception word reading was 
+      underpinned by semantic activations. The ATL is critically and selectively involved 
+      in reading exception words.
+FAU - Ueno, Taiji
+AU  - Ueno T
+AD  - School of Psychology & Clinical Language Sciences, Centre for Integrative 
+      Neuroscience and Neurodynamics, University of Reading, UK.
+AD  - Faculty of Human Sciences, Takachiho University, Tokyo, Japan.
+AD  - Faculty of Environmental Studies, Nagoya University, Nagoya, Japan.
+FAU - Meteyard, Lotte
+AU  - Meteyard L
+AD  - School of Psychology & Clinical Language Sciences, Centre for Integrative 
+      Neuroscience and Neurodynamics, University of Reading, UK.
+FAU - Hoffman, Paul
+AU  - Hoffman P
+AD  - Centre for Cognitive Ageing and Cognitive Epidemiology (CCACE), Department of 
+      Psychology, University of Edinburgh, Edinburgh, UK.
+FAU - Murayama, Kou
+AU  - Murayama K
+AD  - School of Psychology & Clinical Language Sciences, Centre for Integrative 
+      Neuroscience and Neurodynamics, University of Reading, UK.
+AD  - Kochi University of Technology, Kami, Japan.
+AD  - Hector Research Institute of Education Sciences and Psychology, University of 
+      Tübingen, Tübingen, Germany.
+LA  - eng
+GR  - MR/K026992/1/Medical Research Council/United Kingdom
+GR  - Biotechnology and Biological Sciences Research Council/United Kingdom
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+TA  - Cereb Cortex
+JT  - Cerebral cortex (New York, N.Y. : 1991)
+JID - 9110718
+SB  - IM
+MH  - Adult
+MH  - Brain Mapping
+MH  - Computer Simulation
+MH  - Female
+MH  - Functional Laterality
+MH  - Humans
+MH  - Magnetic Resonance Imaging
+MH  - Male
+MH  - Models, Neurological
+MH  - Random Allocation
+MH  - Reaction Time
+MH  - *Reading
+MH  - *Semantics
+MH  - Temporal Lobe/diagnostic imaging/*physiology
+MH  - Transcranial Magnetic Stimulation
+MH  - United Kingdom
+MH  - Verbal Learning
+MH  - *Vocabulary
+PMC - PMC6041960
+EDAT- 2018/06/08 06:00
+MHDA- 2019/10/11 06:00
+CRDT- 2018/06/08 06:00
+PHST- 2017/10/13 00:00 [received]
+PHST- 2018/05/13 00:00 [accepted]
+PHST- 2018/06/08 06:00 [pubmed]
+PHST- 2019/10/11 06:00 [medline]
+PHST- 2018/06/08 06:00 [entrez]
+AID - 5033553 [pii]
+AID - bhy131 [pii]
+AID - 10.1093/cercor/bhy131 [doi]
+PST - ppublish
+SO  - Cereb Cortex. 2018 Aug 1;28(8):3035-3045. doi: 10.1093/cercor/bhy131.
+
+PMID- 21381826
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20110701
+LR  - 20191210
+IS  - 1931-1559 (Electronic)
+IS  - 0894-4105 (Linking)
+VI  - 25
+IP  - 2
+DP  - 2011 Mar
+TI  - Time perception in spatial neglect: a distorted representation?
+PG  - 193-200
+LID - 10.1037/a0021304 [doi]
+AB  - OBJECTIVE: It has been proposed that time, space, and numbers share the same metrics 
+      and cortical network, the right parietal cortex. Several recent investigations have 
+      demonstrated that the mental number line representation is distorted in neglect 
+      patients. The aim of this study is to investigate the relationship between time and 
+      spatial configuration in neglect patients. METHOD: Fourteen right-brain damaged 
+      patients (six with neglect and eight without neglect), as well as eight age-matched 
+      healthy controls, performed a time discrimination task. A standard tone (short: 700 
+      ms and long: 1,700 ms) had to be confronted in duration to a test tone. Test tone 
+      differed of 100, 200, and 300 ms respect to the standard tone duration. RESULTS: 
+      Neglect patients performed significantly worse than patients without neglect and 
+      healthy controls, irrespective of the duration of the standard tone. CONCLUSION: 
+      These results support the hypothesis that mental representations of space and time 
+      both share, to some extent, a common cortical network. Besides, spatial neglect 
+      seems to distort the time representation, inducing an overestimation of time 
+      durations.
+CI  - (c) 2011 APA, all rights reserved
+FAU - Calabria, Marco
+AU  - Calabria M
+AD  - IRCCS Centro San Giovanni di Dio Fatebenefratelli, Via PILASTRONI, 4; 25125 Brescia, 
+      Italy. calabria.marc@gmail.com
+FAU - Jacquin-Courtois, Sophie
+AU  - Jacquin-Courtois S
+FAU - Miozzo, Antonio
+AU  - Miozzo A
+FAU - Rossetti, Yves
+AU  - Rossetti Y
+FAU - Padovani, Alessandro
+AU  - Padovani A
+FAU - Cotelli, Maria
+AU  - Cotelli M
+FAU - Miniussi, Carlo
+AU  - Miniussi C
+LA  - eng
+PT  - Journal Article
+PL  - United States
+TA  - Neuropsychology
+JT  - Neuropsychology
+JID - 8904467
+SB  - IM
+MH  - Aged
+MH  - Aged, 80 and over
+MH  - Analysis of Variance
+MH  - Case-Control Studies
+MH  - Discrimination, Psychological/*physiology
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Male
+MH  - Middle Aged
+MH  - Perceptual Disorders/*physiopathology
+MH  - Psychomotor Performance
+MH  - Reading
+MH  - Time Perception/*physiology
+EDAT- 2011/03/09 06:00
+MHDA- 2011/07/02 06:00
+CRDT- 2011/03/09 06:00
+PHST- 2011/03/09 06:00 [entrez]
+PHST- 2011/03/09 06:00 [pubmed]
+PHST- 2011/07/02 06:00 [medline]
+AID - 2011-04169-006 [pii]
+AID - 10.1037/a0021304 [doi]
+PST - ppublish
+SO  - Neuropsychology. 2011 Mar;25(2):193-200. doi: 10.1037/a0021304.
+
+PMID- 24521842
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20140401
+LR  - 20181113
+IS  - 1074-9357 (Print)
+IS  - 1074-9357 (Linking)
+VI  - 21
+IP  - 1
+DP  - 2014 Jan-Feb
+TI  - Assessment of neglect dyslexia with functional reading materials.
+PG  - 75-86
+LID - 10.1310/tsr2101-75 [doi]
+AB  - BACKGROUND: Spatial neglect is a neurocognitive disorder that affects perception, 
+      representation, and/or motor planning. Neglect dyslexia in spatial neglect after 
+      right hemisphere damage may co-occur with, or be dissociated from, other spatial 
+      neglect signs. Previous neglect dyslexia research focused on word-level stimuli and 
+      reading errors. Using single words for assessment may leave some people with neglect 
+      dyslexia undiagnosed, and assessment materials that are closer to texts read in real 
+      life may better capture neglect dyslexia. METHOD: The authors tested reading in 67 
+      right hemisphere stroke survivors with 4 types of text materials: words, phrases, an 
+      article, and a menu. RESULTS: Accuracy on reading the menu and article texts was 
+      significantly poorer than reading the words and phrases. The hypothesis that 
+      assessment materials with ecological validity such as reading a menu and reading an 
+      article may be more challenging than reading single words and phrases was supported. 
+      CONCLUSION: Results suggest that neglect dyslexia assessment after stroke should 
+      include text materials comparable to those read in everyday life. Increasing the 
+      spatial extent of training materials in future research might also yield better 
+      functional generalization after right brain stroke.
+FAU - Galletta, Elizabeth E
+AU  - Galletta EE
+AD  - Hunter College, The City University of New York, New York, New York The Graduate 
+      School and University Center, The City University of New York, New York, New York 
+      Kessler Foundation Research Center, West Orange, New Jersey.
+FAU - Campanelli, Luca
+AU  - Campanelli L
+AD  - The Graduate School and University Center, The City University of New York, New 
+      York, New York.
+FAU - Maul, Kristen K
+AU  - Maul KK
+AD  - Kessler Foundation Research Center, West Orange, New Jersey.
+FAU - Barrett, A M
+AU  - Barrett AM
+AD  - Kessler Foundation Research Center, West Orange, New Jersey New Jersey Medical 
+      School, Newark, New Jersey.
+LA  - eng
+GR  - K02 NS047099/NS/NINDS NIH HHS/United States
+GR  - K24 HD062647/HD/NICHD NIH HHS/United States
+GR  - R01 NS055808/NS/NINDS NIH HHS/United States
+GR  - K02 NS47099/NS/NINDS NIH HHS/United States
+PT  - Journal Article
+PT  - Research Support, N.I.H., Extramural
+PT  - Research Support, Non-U.S. Gov't
+PT  - Research Support, U.S. Gov't, Non-P.H.S.
+TA  - Top Stroke Rehabil
+JT  - Topics in stroke rehabilitation
+JID - 9439750
+SB  - IM
+MH  - Aged
+MH  - Aged, 80 and over
+MH  - Dyslexia/*complications/*etiology
+MH  - Female
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - Logistic Models
+MH  - Male
+MH  - Middle Aged
+MH  - Neuropsychological Tests
+MH  - Perceptual Disorders/*complications/*etiology
+MH  - Predictive Value of Tests
+MH  - Reading
+MH  - Stroke/*complications
+PMC - PMC3929236
+MID - NIHMS496505
+OTO - NOTNLM
+OT  - assessment
+OT  - neglect dyslexia
+OT  - right hemisphere damage
+OT  - spatial neglect
+EDAT- 2014/02/14 06:00
+MHDA- 2014/04/02 06:00
+CRDT- 2014/02/14 06:00
+PHST- 2014/02/14 06:00 [entrez]
+PHST- 2014/02/14 06:00 [pubmed]
+PHST- 2014/04/02 06:00 [medline]
+AID - M40056P32211T245 [pii]
+AID - 10.1310/tsr2101-75 [doi]
+PST - ppublish
+SO  - Top Stroke Rehabil. 2014 Jan-Feb;21(1):75-86. doi: 10.1310/tsr2101-75.
+
+PMID- 2265933
+OWN - NLM
+STAT- MEDLINE
+DCOM- 19910212
+LR  - 20190828
+IS  - 0020-7454 (Print)
+IS  - 0020-7454 (Linking)
+VI  - 53
+IP  - 2-4
+DP  - 1990 Aug
+TI  - Relation of spatial reasoning ability to hand performance in male and female 
+      left-handers to familial sinistrality and writing hand.
+PG  - 143-55
+AB  - The relation of mental ability for spatial reasoning to hand performance was studied 
+      in male and female left-handers considering familial sinistrality and writing hand. 
+      Hand performance was assessed by a dot-filling test; hand preference was assessed by 
+      the Edinburgh Handedness Inventory (Geschwind scores). Nonverbal intelligence 
+      (spatial reasoning) was measured by the Cattell's Culture Fair Intelligence Test. 
+      The relationship between IQ and hand performance was found to be more complicated 
+      than expected. This was associated with sex, familial sinistrality, and writing 
+      hand, which created different patterns in interactions between motor and cognitive 
+      systems. It was concluded that the brain benefits from different strategies by using 
+      both hemispheres in a competitive and complementary manner where necessary to 
+      achieve a high visual-spatial performance depending upon genetic preprograms.
+FAU - Tan, U
+AU  - Tan U
+AD  - Atatürk University, Medical Faculty, Erzurum, Turkey.
+LA  - eng
+PT  - Journal Article
+PL  - England
+TA  - Int J Neurosci
+JT  - The International journal of neuroscience
+JID - 0270707
+SB  - IM
+MH  - Adult
+MH  - Female
+MH  - *Functional Laterality
+MH  - Hand/*physiology
+MH  - *Handwriting
+MH  - Humans
+MH  - *Intelligence
+MH  - Male
+MH  - *Motor Skills
+MH  - Sex Characteristics
+MH  - *Space Perception
+EDAT- 1990/08/01 00:00
+MHDA- 1990/08/01 00:01
+CRDT- 1990/08/01 00:00
+PHST- 1990/08/01 00:00 [pubmed]
+PHST- 1990/08/01 00:01 [medline]
+PHST- 1990/08/01 00:00 [entrez]
+AID - 10.3109/00207459008986596 [doi]
+PST - ppublish
+SO  - Int J Neurosci. 1990 Aug;53(2-4):143-55. doi: 10.3109/00207459008986596.
+
+PMID- 280219
+OWN - NLM
+STAT- MEDLINE
+DCOM- 19781227
+LR  - 20190616
+IS  - 0077-8923 (Print)
+IS  - 0077-8923 (Linking)
+VI  - 299
+DP  - 1977 Sep 30
+TI  - An anthropological perspective on the evolution and lateralization of the brain.
+PG  - 424-47
+AB  - The purpose of this paper is to review the anthropological evidence relating to the 
+      cultural determinants of the right-hand first postaulted by Hertz in his classic 
+      study. Also a genetic/cultural conformity model of handedness is presented that 
+      postulates that the incidence of handedness in a society is held to result both from 
+      the genetic expression of handedness interacting with cultural pressures towards 
+      conformity. The evolutionary basis for the hemispheric functional organization into 
+      cognitive and perceptual hemispheric functions is discussed in terms of 
+      "right-handed dominant homozygotes, DD," "heterozygotes, DR," mixed-handers, and 
+      "left-handed recessive homozygotes, RR." The cross-cultural distribution of 
+      handedness provides support for this model since the more conforming 
+      agriculturalists as measured by the Asch Test have a significantly lower incidence 
+      of left-handedness (0.59%, 1.5% and 3.4%), while the more permissively socialized 
+      Eskimo and Arunta hunters, who are seen to be more independent on the Asch Test, 
+      have 11.3% and 10.5% left-handers, respectively. Also, due to the greater pressures 
+      for females to conform in agricultural societies, the incidence of female 
+      left-handedness in agricultural societies is 0% out of 330 female Ss, with 3.8%, 
+      0.79%, and 2.5% in agricultural males, as contrasted with the Eskimo hunters who 
+      have 12.5% left-handed males and 10.3% left-handed females, showing no significant 
+      sex difference. A further Hong Kong-English study also supports the genetic/cultural 
+      conformity model with a significantly lower incidence of Hong Kong Chinese 
+      left-handers (RR: male = 2.7%, and female = 4.2%). The next section, concerned with 
+      the neonatal sex-hormone differentiation and lateralization processes, provides a 
+      neuropsychologic theory relating to spatial and linguistic skills that is relevant 
+      to the following section, which deals with relationships between laterality and 
+      cognitive style. The results are also presented for the Alaskan Eskimo in relation 
+      to hand, eye, auditory dominance and cognitive style. The analysis of Eskimo 
+      fixed-versus mixed-laterality data also confirms, as predicted, that both within and 
+      across a modality (e.g., right hand/right eye/right ear) fixed right-dominance 
+      Eskimo Ss are more field-independent than mixed-dominance Ss, while the fixed 
+      left-dominance Ss are the most field-dependent and have lower spatial skills. The 
+      discussion section reviews the papers relating to the genetic/conformity model of 
+      handedness, as well as laterality and cognitive style. The evolutionary adaptive 
+      significance of sex differences in gonadal differentiation and lateralization of the 
+      brain on spatial and linguistic skills are also reviewed. The conclusions are 
+      concerned with the implications for biosocial theory and the rapidly changing 
+      incidence of left-handedness due to accompanying changes in cultural pressures both 
+      within and across cultures.
+FAU - Dawson, J L
+AU  - Dawson JL
+LA  - eng
+PT  - Journal Article
+PL  - United States
+TA  - Ann N Y Acad Sci
+JT  - Annals of the New York Academy of Sciences
+JID - 7506858
+RN  - 0 (Estrogens)
+RN  - 3XMK78S47O (Testosterone)
+SB  - IM
+MH  - Adult
+MH  - Animals
+MH  - *Anthropology, Cultural
+MH  - *Anthropology, Physical
+MH  - *Biological Evolution
+MH  - Brain/*physiology
+MH  - Cognition/physiology
+MH  - Cross-Cultural Comparison
+MH  - Dominance, Cerebral/*physiology
+MH  - Estrogens/blood
+MH  - Female
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - Infant, Newborn
+MH  - Male
+MH  - Perception/physiology
+MH  - Phenotype
+MH  - Rats
+MH  - Speech/physiology
+MH  - Testosterone/blood
+EDAT- 1977/09/30 00:00
+MHDA- 1977/09/30 00:01
+CRDT- 1977/09/30 00:00
+PHST- 1977/09/30 00:00 [pubmed]
+PHST- 1977/09/30 00:01 [medline]
+PHST- 1977/09/30 00:00 [entrez]
+AID - 10.1111/j.1749-6632.1977.tb41927.x [doi]
+PST - ppublish
+SO  - Ann N Y Acad Sci. 1977 Sep 30;299:424-47. doi: 10.1111/j.1749-6632.1977.tb41927.x.
+
+PMID- 28964939
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20180724
+LR  - 20180914
+IS  - 1973-8102 (Electronic)
+IS  - 0010-9452 (Linking)
+VI  - 96
+DP  - 2017 Nov
+TI  - Face perception in pure alexia: Complementary contributions of the left fusiform 
+      gyrus to facial identity and facial speech processing.
+PG  - 59-72
+LID - S0010-9452(17)30286-1 [pii]
+LID - 10.1016/j.cortex.2017.08.029 [doi]
+AB  - Recent concepts of cerebral visual processing predict from overlapping patterns of 
+      face and word activation in cortex that left fusiform lesions will not only cause 
+      pure alexia but also lead to mild impairments of face processing. Our goal was to 
+      determine if alexic subjects had deficits in facial identity processing similar to 
+      those seen after right fusiform lesions, or complementary deficits affecting 
+      different aspects of face processing. We studied four alexic patients whose lesions 
+      involved the left fusiform gyrus and one prosopagnosic subject with a right fusiform 
+      lesion, on standard tests of face perception and recognition. We evaluated their 
+      ability first to process faces in linear contour images, and second to detect, 
+      discriminate, identify and integrate facial speech patterns into perception. We 
+      found that all five patients were impaired in face matching across viewpoint, but 
+      the alexic subjects performed worse with line-drawn faces, while the prosopagnosic 
+      subject did not. Alexic subjects could detect facial speech patterns but had trouble 
+      identifying them and did not integrate facial speech patterns with speech sounds, 
+      whereas identification and integration was intact in the prosopagnosic subject. We 
+      conclude that, in addition to their role in reading, the left-sided regions damaged 
+      in alexic subjects participate in the perception of facial identity but in a 
+      non-redundant fashion, focusing on the information in linear contours at higher 
+      spatial frequencies. In addition they have a dominant role in processing facial 
+      speech patterns, another visual aspect of language processing.
+CI  - Copyright © 2017 Elsevier Ltd. All rights reserved.
+FAU - Albonico, Andrea
+AU  - Albonico A
+AD  - Human Vision and Eye Movement Laboratory, Departments of Medicine (Neurology), 
+      Ophthalmology and Visual Sciences, Psychology, University of British Columbia, 
+      Vancouver, Canada; NeuroMI - Milan Center for Neuroscience, Milano, Italy.
+FAU - Barton, Jason J S
+AU  - Barton JJS
+AD  - Human Vision and Eye Movement Laboratory, Departments of Medicine (Neurology), 
+      Ophthalmology and Visual Sciences, Psychology, University of British Columbia, 
+      Vancouver, Canada. Electronic address: jasonbarton@shaw.ca.
+LA  - eng
+GR  - MOP-106511/CIHR/Canada
+GR  - MOP-102567/CIHR/Canada
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20170904
+PL  - Italy
+TA  - Cortex
+JT  - Cortex; a journal devoted to the study of the nervous system and behavior
+JID - 0100725
+SB  - IM
+MH  - Adult
+MH  - Aged
+MH  - Alexia, Pure/*physiopathology
+MH  - Facial Recognition/physiology
+MH  - Female
+MH  - Form Perception/physiology
+MH  - Functional Laterality/*physiology
+MH  - Humans
+MH  - Male
+MH  - Middle Aged
+MH  - Pattern Recognition, Visual/*physiology
+MH  - Photic Stimulation/methods
+MH  - *Speech
+OTO - NOTNLM
+OT  - *McGurk illusion
+OT  - *Object recognition
+OT  - *Prosopagnosia
+OT  - *Spatial frequency
+EDAT- 2017/10/02 06:00
+MHDA- 2018/07/25 06:00
+CRDT- 2017/10/02 06:00
+PHST- 2016/08/25 00:00 [received]
+PHST- 2017/05/16 00:00 [revised]
+PHST- 2017/08/24 00:00 [accepted]
+PHST- 2017/10/02 06:00 [pubmed]
+PHST- 2018/07/25 06:00 [medline]
+PHST- 2017/10/02 06:00 [entrez]
+AID - S0010-9452(17)30286-1 [pii]
+AID - 10.1016/j.cortex.2017.08.029 [doi]
+PST - ppublish
+SO  - Cortex. 2017 Nov;96:59-72. doi: 10.1016/j.cortex.2017.08.029. Epub 2017 Sep 4.
+
+PMID- 27450929
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20170828
+LR  - 20171204
+IS  - 1872-6240 (Electronic)
+IS  - 0006-8993 (Linking)
+VI  - 1648
+IP  - Pt A
+DP  - 2016 Oct 1
+TI  - The role of parieto-temporal connectivity in pure neglect dyslexia.
+PG  - 144-151
+LID - S0006-8993(16)30515-7 [pii]
+LID - 10.1016/j.brainres.2016.07.033 [doi]
+AB  - The initial stages of reading are characterised by parallel and effortless access to 
+      letters constituting a word. Neglect dyslexia is an acquired reading disorder 
+      characterised by omission or substitution of the initial or the final letters of 
+      words. Rarely, the disorder appears in a'pure' form that is, without other signs of 
+      spatial neglect. Neglect dyslexia is linked to damage involving the inferior 
+      parietal lobe and regions of the temporal lobe, but the precise anatomical basis of 
+      the pure form of the disorder is unknown. Here, we show that pure neglect dyslexia 
+      is associated with decreased structural connectivity between the inferior parietal 
+      and lateral temporal lobe. We examined patient DM, who following bilateral 
+      occipito-parietal damage presented left neglect dyslexia together with right visual 
+      field loss, but no signs of spatial neglect. DM's reading errors were affected by 
+      word length and were much more frequent for pseudowords than for existing words. 
+      Most errors were omissions or substitutions of the first or second letter, and the 
+      spatial distribution of errors was similar for stimuli presented left or right of 
+      fixation. The brain lesions of DM comprised the inferior and superior parietal 
+      lobule as well as the cuneus and precuneus of the left hemisphere, and the angular 
+      gyrus and lateral occipital cortex of the right hemisphere. Diffusion tensor imaging 
+      revealed bilateral decrease of fibre tracts connecting the inferior parietal lobule 
+      with the superior and middle temporal cortex. These findings suggest that 
+      parieto-temporal connections play a significant role for the deployment of attention 
+      within words during reading.
+CI  - Copyright © 2016 Elsevier B.V. All rights reserved.
+FAU - Ptak, Radek
+AU  - Ptak R
+AD  - Division of Neurorehabilitation, Department of Clinical Neurosciences, University 
+      Hospitals Geneva, Geneva, Switzerland; Laboratory of Cognitive Neurorehabilitation, 
+      Faculty of Medicine, University of Geneva, Switzerland; Faculty of Psychology and 
+      Educational Sciences, University of Geneva, Geneva, Switzerland. Electronic address: 
+      radek.ptak@hcuge.ch.
+FAU - Di Pietro, Marie
+AU  - Di Pietro M
+AD  - Division of Neurorehabilitation, Department of Clinical Neurosciences, University 
+      Hospitals Geneva, Geneva, Switzerland.
+FAU - Pignat, Jean-Michel
+AU  - Pignat JM
+AD  - Unit of Acute Neurorehabilitation, Department of Clinical Neurosciences, University 
+      Hospital Lausanne, 1011 Lausanne, Switzerland.
+LA  - eng
+PT  - Case Reports
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20160720
+PL  - Netherlands
+TA  - Brain Res
+JT  - Brain research
+JID - 0045503
+SB  - IM
+MH  - Diffusion Tensor Imaging
+MH  - Dyslexia/etiology/*physiopathology
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - Male
+MH  - Middle Aged
+MH  - Occipital Lobe/physiopathology
+MH  - Parietal Lobe/*physiopathology
+MH  - Perceptual Disorders/complications
+MH  - Reading
+MH  - Temporal Lobe/*physiopathology
+MH  - Visual Fields/physiology
+OTO - NOTNLM
+OT  - *Disconnection
+OT  - *Neglect dyslexia
+OT  - *Parietal lobe
+OT  - *Reading
+OT  - *Spatial neglect
+OT  - *Temporal lobe
+OT  - *Visual attention
+EDAT- 2016/07/28 06:00
+MHDA- 2017/08/29 06:00
+CRDT- 2016/07/25 06:00
+PHST- 2016/03/06 00:00 [received]
+PHST- 2016/07/01 00:00 [revised]
+PHST- 2016/07/19 00:00 [accepted]
+PHST- 2016/07/25 06:00 [entrez]
+PHST- 2016/07/28 06:00 [pubmed]
+PHST- 2017/08/29 06:00 [medline]
+AID - S0006-8993(16)30515-7 [pii]
+AID - 10.1016/j.brainres.2016.07.033 [doi]
+PST - ppublish
+SO  - Brain Res. 2016 Oct 1;1648(Pt A):144-151. doi: 10.1016/j.brainres.2016.07.033. Epub 
+      2016 Jul 20.
+
+PMID- 18420234
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20080826
+LR  - 20191210
+IS  - 0028-3932 (Print)
+IS  - 0028-3932 (Linking)
+VI  - 46
+IP  - 8
+DP  - 2008
+TI  - Hippocampal activation during episodic and semantic memory retrieval: comparing 
+      category production and category cued recall.
+PG  - 2109-21
+LID - 10.1016/j.neuropsychologia.2008.02.030 [doi]
+AB  - Whether or not the hippocampus participates in semantic memory retrieval has been 
+      the focus of much debate in the literature. However, few neuroimaging studies have 
+      directly compared hippocampal activation during semantic and episodic retrieval 
+      tasks that are well matched in all respects other than the source of the retrieved 
+      information. In Experiment 1, we compared hippocampal fMRI activation during a 
+      classic semantic memory task, category production, and an episodic version of the 
+      same task, category cued recall. Left hippocampal activation was observed in both 
+      episodic and semantic conditions, although other regions of the brain clearly 
+      distinguished the two tasks. Interestingly, participants reported using retrieval 
+      strategies during the semantic retrieval task that relied on autobiographical and 
+      spatial information; for example, visualizing themselves in their kitchen while 
+      producing items for the category kitchen utensils. In Experiment 2, we considered 
+      whether the use of these spatial and autobiographical retrieval strategies could 
+      have accounted for the hippocampal activation observed in Experiment 1. Categories 
+      were presented that elicited one of three retrieval strategy types, autobiographical 
+      and spatial, autobiographical and nonspatial, and neither autobiographical nor 
+      spatial. Once again, similar hippocampal activation was observed for all three 
+      category types, regardless of the inclusion of spatial or autobiographical content. 
+      We conclude that the distinction between semantic and episodic memory is more 
+      complex than classic memory models suggest.
+FAU - Ryan, Lee
+AU  - Ryan L
+AD  - Cognition & Neuroimaging Laboratories, Department of Psychology, University of 
+      Arizona, Tucson, AZ 85721-0068, USA. ryant@email.arizona.edu
+FAU - Cox, Christine
+AU  - Cox C
+FAU - Hayes, Scott M
+AU  - Hayes SM
+FAU - Nadel, Lynn
+AU  - Nadel L
+LA  - eng
+GR  - R01 NS044107-05/NS/NINDS NIH HHS/United States
+GR  - R01 NS044107-01A1/NS/NINDS NIH HHS/United States
+GR  - R01 NS044107-03/NS/NINDS NIH HHS/United States
+GR  - R01 NS044107-04/NS/NINDS NIH HHS/United States
+GR  - R01 NS044107-03S1/NS/NINDS NIH HHS/United States
+GR  - R01 NS044107/NS/NINDS NIH HHS/United States
+GR  - R01 NS044107-02/NS/NINDS NIH HHS/United States
+PT  - Journal Article
+DEP - 20080318
+TA  - Neuropsychologia
+JT  - Neuropsychologia
+JID - 0020713
+RN  - S88TT14065 (Oxygen)
+SB  - IM
+MH  - Adolescent
+MH  - Adult
+MH  - *Brain Mapping
+MH  - *Cues
+MH  - Female
+MH  - Functional Laterality
+MH  - Hippocampus/blood supply/*physiology
+MH  - Humans
+MH  - Image Processing, Computer-Assisted
+MH  - Male
+MH  - Mental Recall/*physiology
+MH  - Oxygen/blood
+MH  - Retention, Psychology/*physiology
+MH  - *Semantics
+PMC - PMC2482601
+MID - NIHMS56375
+EDAT- 2008/04/19 09:00
+MHDA- 2008/08/30 09:00
+CRDT- 2008/04/19 09:00
+PHST- 2007/10/03 00:00 [received]
+PHST- 2008/02/25 00:00 [revised]
+PHST- 2008/02/25 00:00 [accepted]
+PHST- 2008/04/19 09:00 [pubmed]
+PHST- 2008/08/30 09:00 [medline]
+PHST- 2008/04/19 09:00 [entrez]
+AID - S0028-3932(08)00092-4 [pii]
+AID - 10.1016/j.neuropsychologia.2008.02.030 [doi]
+PST - ppublish
+SO  - Neuropsychologia. 2008;46(8):2109-21. doi: 10.1016/j.neuropsychologia.2008.02.030. 
+      Epub 2008 Mar 18.
+
+PMID- 26666706
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20161013
+LR  - 20181113
+IS  - 2045-2322 (Electronic)
+IS  - 2045-2322 (Linking)
+VI  - 5
+DP  - 2015 Dec 15
+TI  - Effect of handedness on brain activity patterns and effective connectivity network 
+      during the semantic task of Chinese characters.
+PG  - 18262
+LID - 10.1038/srep18262 [doi]
+LID - 18262
+AB  - Increasing efforts have been denoted to elucidating the effective connectivity (EC) 
+      among brain regions recruited by certain language task; however, it remains unclear 
+      the impact of handedness on the EC network underlying language processing. In 
+      particularly, this has not been investigated in Chinese language, which shows 
+      several differences from alphabetic language. This study thereby explored the 
+      functional activity patterns and the EC network during a Chinese semantic task based 
+      on functional MRI data of healthy left handers (LH) and right handers (RH). We found 
+      that RH presented a left lateralized activity pattern in cerebral cortex and a right 
+      lateralized pattern in cerebellum; while LH were less lateralized than RH in both 
+      cerebral and cerebellar areas. The conditional Granger causality method in 
+      deconvolved BOLD level further demonstrated more interhemispheric directional 
+      connections in LH than RH group, suggesting better bihemispheric coordination and 
+      increased interhemispheric communication in LH. Furthermore, we found significantly 
+      increased EC from right middle occipital gyrus to bilateral insula (INS) while 
+      decreased EC from left INS to left precentral gyrus in LH group comparing to RH 
+      group, implying that handedness may differentiate the causal relationship of 
+      information processing in integration of visual-spatial analysis and semantic word 
+      retrieval of Chinese characters.
+FAU - Gao, Qing
+AU  - Gao Q
+AD  - School of Mathematical Sciences, University of Electronic Science and Technology of 
+      China, Chengdu, 611731, China.
+FAU - Wang, Junping
+AU  - Wang J
+AD  - Department of Radiology, Tianjin Medical University General Hospital, Tianjin, 
+      300052, China.
+FAU - Yu, Chunshui
+AU  - Yu C
+AD  - Department of Radiology, Tianjin Medical University General Hospital, Tianjin, 
+      300052, China.
+FAU - Chen, Huafu
+AU  - Chen H
+AD  - Key laboratory for Neuroinformation of Ministry of Education, School of Life Science 
+      and Technology, University of Electronic Science and Technology of China, Chengdu, 
+      610054, China.
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20151215
+TA  - Sci Rep
+JT  - Scientific reports
+JID - 101563288
+SB  - IM
+MH  - Asian Continental Ancestry Group
+MH  - Brain/*physiology
+MH  - Brain Mapping
+MH  - China
+MH  - *Connectome
+MH  - *Functional Laterality
+MH  - Humans
+MH  - Magnetic Resonance Imaging
+MH  - *Semantics
+PMC - PMC4678893
+EDAT- 2015/12/17 06:00
+MHDA- 2016/10/14 06:00
+CRDT- 2015/12/16 06:00
+PHST- 2015/06/29 00:00 [received]
+PHST- 2015/11/13 00:00 [accepted]
+PHST- 2015/12/16 06:00 [entrez]
+PHST- 2015/12/17 06:00 [pubmed]
+PHST- 2016/10/14 06:00 [medline]
+AID - srep18262 [pii]
+AID - 10.1038/srep18262 [doi]
+PST - epublish
+SO  - Sci Rep. 2015 Dec 15;5:18262. doi: 10.1038/srep18262.
+
+PMID- 2265931
+OWN - NLM
+STAT- MEDLINE
+DCOM- 19910212
+LR  - 20190828
+IS  - 0020-7454 (Print)
+IS  - 0020-7454 (Linking)
+VI  - 53
+IP  - 2-4
+DP  - 1990 Aug
+TI  - Relation of hand skill to spatial reasoning in male and female left-handers with 
+      left- and right-hand writing.
+PG  - 121-33
+AB  - The relation of mental ability for spatial reasoning (Cattell's Culture Fair 
+      Intelligence Test) to hand skill assessed by peg-moving task was studied in normal 
+      left-handers. Nonlinear, quadratic relationships were established between these two 
+      parameters exhibiting different characteristics according to sex and writing hand. 
+      It was concluded that the contributions of the right and left cerebral hemispheres 
+      to the cognitive-motor output of the brain depend on sex and writing hand as well as 
+      the degree of left-handedness in left-handers.
+FAU - Tan, U
+AU  - Tan U
+AD  - Atatürk University, Medical Faculty, Erzurum, Turkey.
+LA  - eng
+PT  - Journal Article
+PL  - England
+TA  - Int J Neurosci
+JT  - The International journal of neuroscience
+JID - 0270707
+SB  - IM
+MH  - Adolescent
+MH  - Adult
+MH  - Child
+MH  - Female
+MH  - *Functional Laterality
+MH  - Hand/*physiology
+MH  - *Handwriting
+MH  - Humans
+MH  - *Intelligence
+MH  - Male
+MH  - *Motor Skills
+MH  - Neuropsychological Tests
+MH  - Sex Characteristics
+MH  - *Space Perception
+MH  - Time Factors
+EDAT- 1990/08/01 00:00
+MHDA- 1990/08/01 00:01
+CRDT- 1990/08/01 00:00
+PHST- 1990/08/01 00:00 [pubmed]
+PHST- 1990/08/01 00:01 [medline]
+PHST- 1990/08/01 00:00 [entrez]
+AID - 10.3109/00207459008986594 [doi]
+PST - ppublish
+SO  - Int J Neurosci. 1990 Aug;53(2-4):121-33. doi: 10.3109/00207459008986594.
+
+PMID- 23344530
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20140204
+LR  - 20181113
+IS  - 1612-4790 (Electronic)
+IS  - 1612-4782 (Linking)
+VI  - 14
+IP  - 3
+DP  - 2013 Aug
+TI  - Priming the mental time-line: effects of modality and processing mode.
+PG  - 231-44
+LID - 10.1007/s10339-013-0537-5 [doi]
+AB  - The notion of a mental time-line (i.e., past corresponds to left and future 
+      corresponds to right) supports the conceptual metaphor view assuming that abstract 
+      concepts like "time" are grounded in cognitively more accessible concepts like 
+      "space." In five experiments, we further investigated the relationship between 
+      temporal and spatial representations and examined whether or not the spatial 
+      correspondents of time are unintentionally activated. We employed a priming 
+      paradigm, in which visual or auditory prime words (i.e., temporal adverbs such as 
+      yesterday, tomorrow) preceded a colored square. In all experiments, participants 
+      discriminated the color of this square by responding with the left or the right 
+      hand. Although the temporal reference of the priming adverb was task irrelevant in 
+      Experiment 1, visually presented primes facilitated responses to the square in 
+      correspondence with the direction of the mental time-line. This priming effect was 
+      absent in Experiments 2, 3, and 5, in which the primes were presented auditorily and 
+      the temporal reference of the words could be ignored. The effect, however, emerged 
+      when attention was oriented to the temporal content of the auditory prime words in 
+      Experiment 4. The results suggest that task demands differentially modulate the 
+      activation of the mental time-line within the visual and auditory modality and 
+      support a flexible association between conceptual codes.
+FAU - Rolke, Bettina
+AU  - Rolke B
+AD  - Evolutionary Cognition, Department of Psychology, University of Tübingen, 
+      Schleichstrasse 4, 72076, Tübingen, Germany. bettina.rolke@uni-tuebingen.de
+FAU - Fernández, Susana Ruiz
+AU  - Fernández SR
+FAU - Schmid, Mareike
+AU  - Schmid M
+FAU - Walker, Matthias
+AU  - Walker M
+FAU - Lachmair, Martin
+AU  - Lachmair M
+FAU - López, Juan José Rahona
+AU  - López JJ
+FAU - Hervás, Gonzalo
+AU  - Hervás G
+FAU - Vázquez, Carmelo
+AU  - Vázquez C
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20130124
+PL  - Germany
+TA  - Cogn Process
+JT  - Cognitive processing
+JID - 101177984
+SB  - IM
+MH  - Acoustic Stimulation
+MH  - Attention/physiology
+MH  - Cognition/physiology
+MH  - *Cues
+MH  - Female
+MH  - Fixation, Ocular
+MH  - Functional Laterality/physiology
+MH  - Humans
+MH  - Male
+MH  - Photic Stimulation
+MH  - Psychomotor Performance/physiology
+MH  - Reaction Time/physiology
+MH  - Reading
+MH  - Space Perception/physiology
+MH  - Time Perception/*physiology
+MH  - Young Adult
+EDAT- 2013/01/25 06:00
+MHDA- 2014/02/05 06:00
+CRDT- 2013/01/25 06:00
+PHST- 2012/09/21 00:00 [received]
+PHST- 2013/01/04 00:00 [accepted]
+PHST- 2013/01/25 06:00 [entrez]
+PHST- 2013/01/25 06:00 [pubmed]
+PHST- 2014/02/05 06:00 [medline]
+AID - 10.1007/s10339-013-0537-5 [doi]
+PST - ppublish
+SO  - Cogn Process. 2013 Aug;14(3):231-44. doi: 10.1007/s10339-013-0537-5. Epub 2013 Jan 
+      24.
+
+PMID- 22470500
+OWN - NLM
+STAT- MEDLINE
+DCOM- 20120803
+LR  - 20181113
+IS  - 1932-6203 (Electronic)
+IS  - 1932-6203 (Linking)
+VI  - 7
+IP  - 3
+DP  - 2012
+TI  - Human infants and baboons show the same pattern of handedness for a communicative 
+      gesture.
+PG  - e33959
+LID - 10.1371/journal.pone.0033959 [doi]
+LID - e33959
+AB  - To test the role of gestures in the origin of language, we studied hand preferences 
+      for grasping or pointing to objects at several spatial positions in human infants 
+      and adult baboons. If the roots of language are indeed in gestural communication, we 
+      expect that human infants and baboons will present a comparable difference in their 
+      pattern of laterality according to task: both should be more 
+      right-hand/left-hemisphere specialized when communicating by pointing than when 
+      simply grasping objects. Our study is the first to test both human infants and 
+      baboons on the same communicative task. Our results show remarkable convergence in 
+      the distribution of the two species' hand biases on the two kinds of tasks: In both 
+      human infants and baboons, right-hand preference was significantly stronger for the 
+      communicative task than for grasping objects. Our findings support the hypothesis 
+      that left-lateralized language may be derived from a gestural communication system 
+      that was present in the common ancestor of baboons and humans.
+FAU - Meunier, Helene
+AU  - Meunier H
+AD  - Primatology Centre of Strasbourg University, Fort Foch, Niederhausbergen, France. 
+      meunier.h@gmail.com
+FAU - Vauclair, Jacques
+AU  - Vauclair J
+FAU - Fagard, Jacqueline
+AU  - Fagard J
+LA  - eng
+PT  - Journal Article
+PT  - Research Support, Non-U.S. Gov't
+DEP - 20120321
+TA  - PLoS One
+JT  - PloS one
+JID - 101285081
+SB  - IM
+MH  - Animal Communication
+MH  - Animals
+MH  - Female
+MH  - Functional Laterality/*physiology
+MH  - *Gestures
+MH  - Humans
+MH  - Infant
+MH  - Male
+MH  - Papio
+PMC - PMC3309962
+COIS- Competing Interests: The authors have declared that no competing interests exist.
+EDAT- 2012/04/04 06:00
+MHDA- 2012/08/04 06:00
+CRDT- 2012/04/04 06:00
+PHST- 2011/09/01 00:00 [received]
+PHST- 2012/02/20 00:00 [accepted]
+PHST- 2012/04/04 06:00 [entrez]
+PHST- 2012/04/04 06:00 [pubmed]
+PHST- 2012/08/04 06:00 [medline]
+AID - PONE-D-11-19248 [pii]
+AID - 10.1371/journal.pone.0033959 [doi]
+PST - ppublish
+SO  - PLoS One. 2012;7(3):e33959. doi: 10.1371/journal.pone.0033959. Epub 2012 Mar 21.

--- a/test/line-endings.js
+++ b/test/line-endings.js
@@ -1,0 +1,55 @@
+var _ = require('lodash');
+var expect = require('chai').expect;
+var fs = require('fs');
+var rl = require('../index');
+
+// Loop over example files with different encodings which all should pass identical tests
+var files = ['/data/language-LF.nbib', '/data/language-CRLF.nbib'];
+for (var i in files) {
+
+    describe('MEDLINE line endings compatibility test -  case:' + files[i], function () {
+        var resErr;
+        var data = {};
+        // copy the filename, to prevent using reference to changing global string object to the async before()
+        var filename = '' + files[i]; 
+
+        before(function (next) {
+            this.timeout(60 * 1000);
+            rl.parse(fs.readFileSync(__dirname + filename, 'utf-8'))
+                .on('error', function (err) {
+                    resErr = err;
+                    next();
+                })
+                .on('ref', function (ref) {
+                    data[ref.recNo] = ref;
+                })
+                .on('end', next);
+        });
+
+        it('should not raise an error', function () {
+            expect(resErr).to.be.not.ok;
+        });
+
+        it('end count should be accurate', function () {
+            expect(_.keys(data)).to.have.length(40);
+        });
+
+        it('should return random sample', function () {
+            var sample = data['280219'];
+            expect(sample).to.be.ok;
+            expect(sample).to.have.property('title', 'An anthropological perspective on the evolution and lateralization of the brain.');
+            expect(sample).to.have.property('journal', 'Annals of the New York Academy of Sciences');
+            expect(sample).to.have.property('authors');
+            expect(sample.authors).to.deep.equal(['Dawson, J L']);
+            expect(sample).to.have.property('date', '1977 Sep 30');
+            expect(sample).to.have.property('type', 'unknown');
+            expect(sample).to.have.property('language', 'eng');
+            expect(sample).to.have.property('abstract');
+            expect(sample.abstract).to.match(/^The purpose of this paper/);
+            expect(sample.abstract).to.match(/The next section, concerned with/);
+            expect(sample.abstract).to.match(/within and across cultures\.$/);
+            // expect(sample.keywords).to.deep.equal(['', 'No keywords']);
+            expect(sample).to.have.property('doi', '10.1111/j.1749-6632.1977.tb41927.x [doi]');
+        });
+    });
+}


### PR DESCRIPTION
Hi,

I had a user submit a NBIB file downloaded from PubMed which would not import, and I noticed it had CRLF newlines which confuse the parser. I guess someone had text-edited the file at some point on Windows (probably manually gluing export pieces together).

I couldn't see a anything about newline in the specification here https://www.nlm.nih.gov/bsd/mms/medlineelements.html - so I'm not sure what the canon is.

After considering various approaches, I've added a "normalise" step to just strip them and added a test with the file in both CRLF and LF formats.

Re. performance. I did add a content.indexOf() conditional first to try to optimise and avoid the replace on the majority of cases where there are no windows newlines - but after benchmarking it turned out to be of almost no benefit in recent Node versions, where replace() seems to be just as fast. Anyway this line only gets run once per file, and any difference only showed up after 10,000 iterations!

thanks